### PR TITLE
Added a timezone variable to vars and modified the README and Unifi deployment manifest files.

### DIFF
--- a/Unifi_Controller/README.md
+++ b/Unifi_Controller/README.md
@@ -12,7 +12,7 @@ Approximate Deployment Time: 10-15 minutes
 
 * [Project Docker Containers](https://github.com/linuxserver/docker-unifi)
 
-**Requirements:**  
+**Requirements:**
 
     1) Exported NFS Server with which Kubernetes can communicate.  
     2) Working load balancer integrated with Kubernetes Services. (https://metallb.universe.tf/)  
@@ -20,15 +20,16 @@ Approximate Deployment Time: 10-15 minutes
         * pip install openshift kubernetes pyyaml 
         * If you're on MacOS, you might have to do this instead (https://github.com/ansible/ansible/issues/43637#issuecomment-443495763).
 
-**Instructions:**  
+**Instructions:**
 
 *Optional:*
 
     1) Export a backup of your existing Unifi Controller settings to a .unf file.
+    2) If you plan on running the controller on a different network than your AP's, you can likely set DHCP options for remote discovery on your router. Instructions can be found here: https://help.ubnt.com/hc/en-us/articles/204909754-UniFi-Device-Adoption-Methods-for-Remote-UniFi-Controllers
 
 *Required:*
 
-    1) Stop your existing Unifi Controller service.
+    1) Stop any existing Unifi Controllers on the same network.
     2) Make sure you satisfy the above requirements.   
     3) Fill out the `vars.yml` file with the parameters specific to your environment.  
     4) Execute the playbook: `ansible-playbook provision.yml`.  
@@ -54,9 +55,8 @@ Approximate Deployment Time: 10-15 minutes
         - https://community.ubnt.com/t5/UniFi-Feature-Requests/Unifi-Controller-Redundancy/idi-p/680341
         - Currently trying to decentralize the MongoDB instance to resolve this.
         - Installing a proper certificate may remediate the issue.
-    2) Unfortunately I have not gotten Device Discovery to work yet. It could be my network. 
 
-**Deletion:**  
+**Deletion:**
 
     1) You can roll back this deployment with the `delete.yml` playbook: `ansible-playbook delete.yml`.
-        - Please note, this will not remove the deployed namespace because I could not be sure you didn't specify an existing namespace. I would hate to delete your `default` for example. So you must manually clean that up. `kubectl delete ns >namespace name<`
+        - Please note, this will not remove the deployed namespace because I cannot be sure you didn't specify an existing namespace. I would hate to delete your `default` for example. So you must manually clean that up. `kubectl delete ns >namespace name<`

--- a/Unifi_Controller/manifests/dep_unifi_controller.yml.j2
+++ b/Unifi_Controller/manifests/dep_unifi_controller.yml.j2
@@ -34,7 +34,7 @@ spec:
                   image: linuxserver/unifi-controller:5.9
                   env:
                       - name: TZ
-                        value: "Pacific"
+                        value: "{{ unifi_controller_timezone }} "
                       - name: PUID
                         value: "1002"
                       - name: PGID

--- a/Unifi_Controller/vars.yml
+++ b/Unifi_Controller/vars.yml
@@ -1,6 +1,9 @@
 # Namespace to deploy the manifests to.
 unifi_controller_namespace: 'unifi-controller'
 
+# Timezone the Unifi Controller should identify as default.
+unifi_controller_timezone: 'Pacific'
+
 # MetalLB Address Pool that you want to obtain an IP from:
 load_balancer_address_pool: 'LAN'
 


### PR DESCRIPTION
The timezone variable was wrong for the default, I like clicking next more quickly with the setup process.

Rephrased a couple lines in the README file.

Deleted problem 2, as it worked completely fine on my network. More testing should be done, but the other thing that it could have been is that I had an existing internal DNS record of `unifi.danmanners.com` pointing to what would be my Load-Balancer's IP address, and the UAP may have identified that on startup after factory reset. Unclear at this time, but worked great for me out of the box.