### PR TITLE
feat: Redirect HTTP to HTTPS on public gateways

### DIFF
--- a/public/bluebird/resources/istio/gateway.yml
+++ b/public/bluebird/resources/istio/gateway.yml
@@ -14,6 +14,8 @@ spec:
         name: http
         number: 80
         protocol: HTTP
+      tls:
+        httpsRedirect: true
     - hosts:
         - 'ganymede.sol.milkyway'
         - 'bluebirdforecast.com'

--- a/public/personal-website/resources/istio/gateway.yml
+++ b/public/personal-website/resources/istio/gateway.yml
@@ -16,6 +16,8 @@ spec:
         name: http
         number: 80
         protocol: HTTP
+      tls:
+        httpsRedirect: true
     - hosts:
         - 'nix.sol.milkyway'
         - 'tjzimmerman.com'


### PR DESCRIPTION
## Summary

Adds `tls.httpsRedirect: true` to the HTTP (port 80) server block of the `personal-website` and `bluebird` Istio Gateways. Any request arriving over HTTP now receives a `301` redirect to the HTTPS equivalent, preserving host and path.

This covers `@` and `www` for `tjzimmerman.com`, `tjzimmerman.dev`, and `bluebirdforecast.com`, as well as the internal LAN hostnames (`nix.sol.milkyway`, `ganymede.sol.milkyway`).

## Notes

- The HTTPS server blocks and VirtualServices are untouched.
- If Cloudflare proxies (orange cloud) this traffic, also enabling **SSL/TLS → Edge Certificates → Always Use HTTPS** redirects at the edge before traffic reaches the origin. This Gateway change covers direct-to-origin / LAN traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)