### PR TITLE
feat: Standardize app workload namespaces on -system suffix

### DIFF
--- a/media/applicationset.yml
+++ b/media/applicationset.yml
@@ -27,6 +27,7 @@ spec:
         path: "{{ path }}"
       destination:
         server: https://kubernetes.default.svc
+        namespace: "{{ path.basenameNormalized }}-system"
       syncPolicy:
         automated:
           prune: true

--- a/media/jellyfin/kustomization.yml
+++ b/media/jellyfin/kustomization.yml
@@ -1,4 +1,4 @@
-namespace: jellyfin
+namespace: jellyfin-system
 
 resources:
   - resources/namespace.yml
@@ -8,7 +8,7 @@ resources:
 helmCharts:
   - includeCRDs: true
     name: jellyfin
-    namespace: jellyfin
+    namespace: jellyfin-system
     releaseName: jellyfin
     repo: https://jellyfin.github.io/jellyfin-helm
     valuesFile: values.yml

--- a/misc/mountaineers-activity-scraper/kustomization.yml
+++ b/misc/mountaineers-activity-scraper/kustomization.yml
@@ -1,4 +1,4 @@
-namespace: mountaineers-activity-scraper
+namespace: mountaineers-activity-scraper-system
 
 resources:
   - resources/namespace.yml

--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -1,4 +1,4 @@
-namespace: bluebird
+namespace: bluebird-system
 
 resources:
 - resources/namespace.yml
@@ -12,7 +12,7 @@ configMapGenerator:
 - files:
   - files/test-connection.sh
   name: test-connection-sh
-  namespace: bluebird
+  namespace: bluebird-system
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/public/bluebird/resources/istio/virtualService.yml
+++ b/public/bluebird/resources/istio/virtualService.yml
@@ -7,7 +7,7 @@ spec:
     - 'ganymede.sol.milkyway'
     - 'bluebirdforecast.com'
     - 'www.bluebirdforecast.com'
-    - 'bluebird-stable.bluebird.svc.cluster.local'
+    - 'bluebird-stable.bluebird-system.svc.cluster.local'
   gateways:
     - 'mesh'
     - 'bluebird'

--- a/public/personal-website/kustomization.yml
+++ b/public/personal-website/kustomization.yml
@@ -1,4 +1,4 @@
-namespace: personal-website
+namespace: personal-website-system
 
 resources:
   - resources/namespace.yml
@@ -10,7 +10,7 @@ resources:
 
 configMapGenerator:
   - name: test-connection-sh
-    namespace: personal-website
+    namespace: personal-website-system
     files:
       - files/test-connection.sh
 

--- a/public/personal-website/resources/istio/virtualService.yml
+++ b/public/personal-website/resources/istio/virtualService.yml
@@ -9,7 +9,7 @@ spec:
     - 'tjzimmerman.dev'
     - 'www.tjzimmerman.com'
     - 'www.tjzimmerman.dev'
-    - 'personal-website-stable.personal-website.svc.cluster.local'
+    - 'personal-website-stable.personal-website-system.svc.cluster.local'
   gateways:
     - 'mesh'
     - 'personal-website'


### PR DESCRIPTION
## Summary

Standardizes first-party **app workload** namespaces on a `<app>-system` suffix, and fixes the failing `jellyfin` sync as a side effect.

- **`media` appset**: sets `destination.namespace: "{{ path.basenameNormalized }}-system"`. This enforces the convention *and* backfills the namespace onto `jellyfin-helm` 3.2.0's Helm-rendered resources — which render without `metadata.namespace` and were causing ArgoCD `InvalidSpecError: Namespace ... is missing`. Upstream fix: jellyfin/jellyfin-helm#148 (approved, unreleased).
- **jellyfin**: `jellyfin` → `jellyfin-system` (interim namespace patch removed).
- **rutorrent**: already `rutorrent-system` — unchanged.
- **bluebird**: `bluebird` → `bluebird-system` (+ VirtualService service FQDN).
- **personal-website**: `personal-website` → `personal-website-system` (+ VirtualService service FQDN).
- **mountaineers-activity-scraper**: → `mountaineers-activity-scraper-system`.

Control-plane / infra namespaces (`argo-cd`, `argo-rollouts`, `cert-manager`, `metallb-system`, `istio-system`, `nfs-subdir-provisioner`, `proxmox-csi-plugin`, `kubelet-csr-approver`) are intentionally left on their conventional names — renaming those via GitOps risks ArgoCD self-management deadlock, broken TLS issuance, and broken volume provisioning.

## ⚠️ Operational notes (not zero-downtime)

Renaming a namespace makes ArgoCD **prune the old namespace and recreate the app in the new one** (`prune: true`, `preserveResourcesOnDeletion: false`).

- bluebird / personal-website / mountaineers are **stateless** → brief downtime only, no data loss.
- jellyfin isn't successfully deployed yet, so no data at risk.
- Gateway TLS cert secrets live in the `istio-gateway` namespace, not the app namespaces, so they're unaffected.
- Suggest merging in a quiet window and watching the first sync so old namespaces fully drain.

## Verification

`kustomize build --enable-helm` on each renamed app renders every resource into its new namespace with no stale `.svc.cluster.local` or bare-namespace references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)