### PR TITLE
feat(bluebird-pr): per-PR preview environments (Argo CD pullRequest generator)

### DIFF
--- a/public/applicationset.yml
+++ b/public/applicationset.yml
@@ -12,6 +12,11 @@ spec:
           - path: "public/*"
           - exclude: true
             path: "public/*.disable*"
+          # bluebird-pr ships its own ApplicationSet + AppProject (applied by the
+          # root generators). Exclude it so this fan-out doesn't also wrap it as a
+          # plain Application under the `public` project.
+          - exclude: true
+            path: "public/bluebird-pr"
   syncPolicy:
     preserveResourcesOnDeletion: false
   template:

--- a/public/applicationset.yml
+++ b/public/applicationset.yml
@@ -12,9 +12,7 @@ spec:
           - path: "public/*"
           - exclude: true
             path: "public/*.disable*"
-          # bluebird-pr ships its own ApplicationSet + AppProject (applied by the
-          # root generators). Exclude it so this fan-out doesn't also wrap it as a
-          # plain Application under the `public` project.
+          # Owns its own ApplicationSet + AppProject (applied by the root generators).
           - exclude: true
             path: "public/bluebird-pr"
   syncPolicy:

--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -7,25 +7,18 @@ spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:
-    # One Application per OPEN, `preview`-labelled PR on the public app repo.
-    # The label is applied by the app repo's pr-preview.yml on same-repo PRs and
-    # requires repo write access, so fork PRs can't self-provision. Public repo,
-    # so no token is needed (anonymous GitHub API; 300s poll stays well under
-    # the 60/hr/IP limit).
     - pullRequest:
         github:
           owner: zimmertr
           repo: bluebird
           labels:
-            - preview
-        requeueAfterSeconds: 300
+            - create pr container
+        requeueAfterSeconds: 60
   template:
     metadata:
       name: "bluebird-pr-{{ .number }}"
       labels:
         app-group: public
-      # Cascade-delete the preview's resources when the PR closes and the
-      # generator drops the Application.
       finalizers:
         - resources-finalizer.argocd.argoproj.io
     spec:
@@ -33,9 +26,6 @@ spec:
       destination:
         server: https://kubernetes.default.svc
         namespace: bluebird-system
-      # Single source: the OCI chart, fully configured inline. Preview topology
-      # is a plain Deployment (no Rollout/Canary) with a SINGLE ingress host, so
-      # no production hostname can leak onto the shared Istio ingress gateway.
       source:
         repoURL: oci://registry-1.docker.io/zimmertr/bluebird-helm
         chart: bluebird-helm
@@ -43,23 +33,19 @@ spec:
         helm:
           releaseName: "bluebird-pr-{{ .number }}"
           valuesObject:
-            replicas: 1
-            strategy: RollingUpdate
             image:
               name: zimmertr/bluebird-pr
-              # Matches the app repo's pr-preview.yml tag: pr-<number>-<head_sha>.
               tag: "pr-{{ .number }}-{{ .head_sha }}"
-            experiment:
-              enabled: false
             ingress:
               enabled: true
               hosts:
                 - "pr-{{ .number }}.ganymede.sol.milkyway"
-              port: 80
-              httpsRedirect: false
-              tls:
-                enabled: false
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        managedNamespaceMetadata:
+          labels:
+            istio-injection: enabled

--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -13,7 +13,7 @@ spec:
           repo: bluebird
           labels:
             - create pr container
-        requeueAfterSeconds: 60
+        requeueAfterSeconds: 300
   template:
     metadata:
       name: "bluebird-pr-{{ .number }}"

--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -1,0 +1,65 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: bluebird-pr
+  namespace: argo-system
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    # One Application per OPEN, `preview`-labelled PR on the public app repo.
+    # The label is applied by the app repo's pr-preview.yml on same-repo PRs and
+    # requires repo write access, so fork PRs can't self-provision. Public repo,
+    # so no token is needed (anonymous GitHub API; 300s poll stays well under
+    # the 60/hr/IP limit).
+    - pullRequest:
+        github:
+          owner: zimmertr
+          repo: bluebird
+          labels:
+            - preview
+        requeueAfterSeconds: 300
+  template:
+    metadata:
+      name: "bluebird-pr-{{ .number }}"
+      labels:
+        app-group: public
+      # Cascade-delete the preview's resources when the PR closes and the
+      # generator drops the Application.
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      project: bluebird-pr
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: bluebird-system
+      # Single source: the OCI chart, fully configured inline. Preview topology
+      # is a plain Deployment (no Rollout/Canary) with a SINGLE ingress host, so
+      # no production hostname can leak onto the shared Istio ingress gateway.
+      source:
+        repoURL: oci://registry-1.docker.io/zimmertr/bluebird-helm
+        chart: bluebird-helm
+        targetRevision: 0.1.1
+        helm:
+          releaseName: "bluebird-pr-{{ .number }}"
+          valuesObject:
+            replicas: 1
+            strategy: RollingUpdate
+            image:
+              name: zimmertr/bluebird-pr
+              # Matches the app repo's pr-preview.yml tag: pr-<number>-<head_sha>.
+              tag: "pr-{{ .number }}-{{ .head_sha }}"
+            experiment:
+              enabled: false
+            ingress:
+              enabled: true
+              hosts:
+                - "pr-{{ .number }}.ganymede.sol.milkyway"
+              port: 80
+              httpsRedirect: false
+              tls:
+                enabled: false
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true

--- a/public/bluebird-pr/appproject.yml
+++ b/public/bluebird-pr/appproject.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: bluebird-pr
+  namespace: argo-system
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Ephemeral per-PR Bluebird preview environments.
+  # Only the published Helm chart (OCI). Must match the ApplicationSet source
+  # repoURL string exactly. No git repo — previews render entirely from the
+  # chart via helm.valuesObject.
+  sourceRepos:
+    - oci://registry-1.docker.io/zimmertr/bluebird-helm
+  # Previews deploy alongside stable in bluebird-system.
+  destinations:
+    - namespace: bluebird-system
+      server: https://kubernetes.default.svc
+  # Previews create only namespaced resources (Deployment, Service, Istio
+  # Gateway/VirtualService) — no cluster-scoped whitelist needed.
+  orphanedResources:
+    warn: true

--- a/public/bluebird-pr/appproject.yml
+++ b/public/bluebird-pr/appproject.yml
@@ -7,16 +7,10 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   description: Ephemeral per-PR Bluebird preview environments.
-  # Only the published Helm chart (OCI). Must match the ApplicationSet source
-  # repoURL string exactly. No git repo — previews render entirely from the
-  # chart via helm.valuesObject.
   sourceRepos:
     - oci://registry-1.docker.io/zimmertr/bluebird-helm
-  # Previews deploy alongside stable in bluebird-system.
   destinations:
     - namespace: bluebird-system
       server: https://kubernetes.default.svc
-  # Previews create only namespaced resources (Deployment, Service, Istio
-  # Gateway/VirtualService) — no cluster-scoped whitelist needed.
   orphanedResources:
     warn: true


### PR DESCRIPTION
## What

**Phase 4b** of the PR-preview initiative. Stands up ephemeral, **LAN-only** Bluebird preview environments for every open, `preview`-labelled PR on the public app repo (`zimmertr/bluebird`), using Argo CD's **pullRequest generator**. Deploys alongside untouched stable in `bluebird-system`; torn down when the PR closes.

Depends on the `bluebird-helm` chart (published) and the app repo's `pr-preview.yml` (merged, builds `zimmertr/bluebird-pr:pr-<n>-<sha>`). Independent of the stable-migration PR (#359) — no file overlap.

## Files

- **`public/bluebird-pr/appproject.yml`** — AppProject `bluebird-pr`. `sourceRepos` = the OCI chart string only; `destinations` = `bluebird-system`. No `clusterResourceWhitelist` (previews create only namespaced kinds) — tighter than the shared `public` project.
- **`public/bluebird-pr/applicationset.yml`** — ApplicationSet `bluebird-pr` (`goTemplate: true`). pullRequest generator filters on the `preview` label, polls every 300s. Per PR → Application `bluebird-pr-<n>`, project `bluebird-pr`, namespace `bluebird-system`.
- **`public/applicationset.yml`** — excludes `public/bluebird-pr` from the `public` fan-out (the **root** generators apply the two files above directly; without the exclude the fan-out would also wrap them as a plain Application under the wrong project).

## Isolation & the shared Istio gateway (verified)

Rendered the chart with the exact preview values. Every resource is release-scoped `bluebird-pr-<n>` and:

- **Single ingress host** `pr-<n>.ganymede.sol.milkyway` — the preview supplies a one-element `ingress.hosts` list via `helm.valuesObject`, so **no production hostname** (`bluebirdforecast.com`/`www`) can leak onto the shared Envoy. (Overriding `hosts[0]` on stable's 3-host list would have — hence inline values, not `$values` reuse.)
- Plain **Deployment** (`strategy: RollingUpdate`, `replicas: 1`) — no Rollout/Canary, no `-canary` Service, no VS weight mutation (so the stable weight `ignoreDifferences` is irrelevant here).
- **Instance-scoped selectors** (`app.kubernetes.io/instance: bluebird-pr-<n>`) — cannot cross-select stable pods in the shared namespace.
- Own Gateway `bluebird-pr-<n>` (selector `istio: gateway`) + VirtualService on port 80, HTTP only.

## Image-tag contract

Argo `pr-{{ .number }}-{{ .head_sha }}` (full 40-char SHA) == CI `pr-<number>-<head.sha>`. The generator only lists **open** PRs, so the app exists only while the PR is open; the resources-finalizer cascade-deletes the preview on close.

## To verify on first sync

- **Tokenless GitHub PR generator**: public repo, so anonymous API (60/hr/IP; fine at 300s). If your Argo build requires a token even for public repos, add a `tokenRef`.
- **Prereqs already in place**: Argo kustomize `--enable-helm` (for #359); the `bluebird-system` namespace exists (owned by stable) so previews need no `CreateNamespace`.
- Wildcard DNS `*.ganymede.sol.milkyway → 192.168.40.150` (Phase 5, OPNsense) is still pending — until then, reach a preview with `curl -H 'Host: pr-<n>.ganymede.sol.milkyway' http://192.168.40.150/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)