### PR TITLE
feat(bluebird-pr): preview banner env + fix shared-namespace sync

### DIFF
--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -53,6 +53,3 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
-        managedNamespaceMetadata:
-          labels:
-            istio-injection: enabled

--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -40,6 +40,13 @@ spec:
               enabled: true
               hosts:
                 - "pr-{{ .number }}.ganymede.sol.milkyway"
+            extraEnv:
+              - name: PREVIEW_BANNER
+                value: "true"
+              - name: PREVIEW_PR
+                value: "{{ .number }}"
+              - name: PREVIEW_COMMIT
+                value: "{{ .head_sha }}"
       syncPolicy:
         automated:
           prune: true

--- a/public/bluebird-pr/appproject.yml
+++ b/public/bluebird-pr/appproject.yml
@@ -12,5 +12,3 @@ spec:
   destinations:
     - namespace: bluebird-system
       server: https://kubernetes.default.svc
-  orphanedResources:
-    warn: true


### PR DESCRIPTION
Two changes to the per-PR preview `bluebird-pr` ApplicationSet/AppProject:

1. **Preview banner env** — inject `PREVIEW_BANNER`/`PREVIEW_PR`/`PREVIEW_COMMIT` via the chart's `extraEnv` so previews render a red banner naming the PR + commit (pairs with zimmertr/bluebird#19). Stable leaves these unset → banner hidden.

2. **Fix shared-namespace sync** — the first real preview (`bluebird-pr-19`) failed with `resource :Namespace is not permitted in project bluebird-pr`. `managedNamespaceMetadata` makes Argo track the `Namespace` as a managed resource (needs a `clusterResourceWhitelist` the project omits) and would fight stable over the shared `bluebird-system` namespace. Dropped it — the namespace already exists and is labeled `istio-injection=enabled` by stable. Also dropped `orphanedResources.warn` (permanent noise when sharing a namespace by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)