### PR TITLE
chore(bluebird): bump chart to 0.1.4

### DIFF
--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -29,7 +29,7 @@ spec:
       source:
         repoURL: oci://registry-1.docker.io/zimmertr/bluebird-helm
         chart: bluebird-helm
-        targetRevision: 0.1.1
+        targetRevision: 0.1.4
         helm:
           releaseName: "bluebird-pr-{{ .number }}"
           valuesObject:

--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -6,7 +6,7 @@ helmCharts:
   releaseName: bluebird
   repo: oci://registry-1.docker.io/zimmertr
   valuesFile: values.yml
-  version: 0.1.1
+  version: 0.1.4
 
 resources:
 - resources/namespace.yml


### PR DESCRIPTION
Bumps the `bluebird-helm` pin from `0.1.1` → `0.1.4` for both stable (`public/bluebird/kustomization.yml`) and the PR preview appset (`public/bluebird-pr/applicationset.yml`).

0.1.4 fixes the Chart.yaml metadata that was blocking ArtifactHub indexing (icon 404 → `/icon.png`; dropped the invalid `artifacthub.io/category`). Chart templates are unchanged from 0.1.1, so the rendered output only differs by the `helm.sh/chart` version label. Migrating off 0.1.1 frees the old broken chart versions to be pruned from the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)