### PR TITLE
feat(bluebird-pr): set LOG_LEVEL=TRACE in preview environments

### DIFF
--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -47,9 +47,6 @@ spec:
                 value: "{{ .number }}"
               - name: PREVIEW_COMMIT
                 value: "{{ .head_sha }}"
-              # Verbose logging for preview/test envs to aid debugging PRs.
-              # The app reads LOG_LEVEL at startup; TRACE is its most verbose
-              # level. Stable deliberately omits this (defaults to WARNING).
               - name: LOG_LEVEL
                 value: "TRACE"
       syncPolicy:

--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -47,6 +47,11 @@ spec:
                 value: "{{ .number }}"
               - name: PREVIEW_COMMIT
                 value: "{{ .head_sha }}"
+              # Verbose logging for preview/test envs to aid debugging PRs.
+              # The app reads LOG_LEVEL at startup; TRACE is its most verbose
+              # level. Stable deliberately omits this (defaults to WARNING).
+              - name: LOG_LEVEL
+                value: "TRACE"
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
## What

Adds `LOG_LEVEL=TRACE` to the `extraEnv` of the `bluebird-pr` ApplicationSet (`public/bluebird-pr/applicationset.yml`), so every per-PR preview/test deployment runs the Bluebird app at its most verbose log level.

## Why

Preview envs are where PRs get exercised before merge — verbose logs (including full upstream Open-Meteo/Overpass request tracing) make debugging a preview far easier. Injected the same way as the existing `PREVIEW_*` vars.

## Blast radius

Preview envs only. Stable is untouched — it doesn't set `LOG_LEVEL` and defaults to `WARNING` in `backend/app/main.py`. No namespace/RBAC changes, so the shared-namespace preview constraints are unaffected.

## Rollout

ArgoCD picks this up on its next sync of the root generators; existing open-PR previews get the new env on their next reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)