### PR TITLE
fix: expand jellyfin-config volume to 50Gi

### DIFF
--- a/media/jellyfin/resources/persistentVolume.yml
+++ b/media/jellyfin/resources/persistentVolume.yml
@@ -40,7 +40,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   capacity:
-    storage: 15Gi
+    storage: 50Gi
   csi:
     driver: csi.proxmox.sinextra.dev
     fsType: xfs

--- a/media/jellyfin/resources/persistentVolumeClaim.yml
+++ b/media/jellyfin/resources/persistentVolumeClaim.yml
@@ -20,7 +20,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 15Gi
+      storage: 50Gi
   storageClassName: proxmox-flashpool
   volumeName: jellyfin-config
 ---


### PR DESCRIPTION
Jellyfin 10.11 added a startup gate requiring 2GiB free on the data directory; the config volume sat at 13.2G/14.9G used (1.8GiB free), so the pod crashloops with exit 139 on every restart. Bump the statically provisioned PV capacity and PVC request from 15Gi to 50Gi. The backing zvol on FlashPool is grown out-of-band with `zfs set volsize`.