### PR TITLE
fix: expand jellyfin-cache volume to 50Gi

### DIFF
--- a/media/jellyfin/resources/persistentVolume.yml
+++ b/media/jellyfin/resources/persistentVolume.yml
@@ -6,7 +6,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   capacity:
-    storage: 15Gi
+    storage: 50Gi
   csi:
     driver: csi.proxmox.sinextra.dev
     fsType: xfs

--- a/media/jellyfin/resources/persistentVolumeClaim.yml
+++ b/media/jellyfin/resources/persistentVolumeClaim.yml
@@ -7,7 +7,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 15Gi
+      storage: 50Gi
   storageClassName: proxmox-flashpool
   volumeName: jellyfin-cache
 ---


### PR DESCRIPTION
Companion to #367: Jellyfin 10.11's startup gate also requires 2GiB free on the cache directory, and the 15Gi cache volume filled to 212KiB free. The cache was wiped to restore service; this bump gives transcode/trickplay churn enough headroom that a refill can't trip the startup check again. Backing zvol grown out-of-band with `zfs set volsize=50G FlashPool/vm-9999-Jellyfin-Cache`.