### PR TITLE
fix: point bluebird PR previews at chart 0.2.0

### DIFF
--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -29,11 +29,6 @@ spec:
       source:
         repoURL: oci://registry-1.docker.io/zimmertr/bluebird-helm
         chart: bluebird-helm
-        # Track the same chart the stable app uses (kustomization.yml). 0.2.0
-        # defaults to a plain Deployment with Istio ingress (mesh on), which is
-        # all an ephemeral preview needs. Bumping off 0.1.4 also lets that old,
-        # immutable chart tag be removed from the registry so Artifact Hub stops
-        # failing its security scan on it.
         targetRevision: 0.2.0
         helm:
           releaseName: "bluebird-pr-{{ .number }}"

--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -29,7 +29,12 @@ spec:
       source:
         repoURL: oci://registry-1.docker.io/zimmertr/bluebird-helm
         chart: bluebird-helm
-        targetRevision: 0.1.4
+        # Track the same chart the stable app uses (kustomization.yml). 0.2.0
+        # defaults to a plain Deployment with Istio ingress (mesh on), which is
+        # all an ephemeral preview needs. Bumping off 0.1.4 also lets that old,
+        # immutable chart tag be removed from the registry so Artifact Hub stops
+        # failing its security scan on it.
+        targetRevision: 0.2.0
         helm:
           releaseName: "bluebird-pr-{{ .number }}"
           valuesObject:


### PR DESCRIPTION
Item 4 (part 1 of 2). Enables clearing the recurring Artifact Hub scan error.

## What
The `bluebird-pr` ApplicationSet pinned chart **0.1.4** while the stable app already runs **0.2.0** (`public/bluebird/kustomization.yml`). This bumps previews to 0.2.0 as well.

- 0.2.0 defaults to a plain Deployment with Istio ingress (`mesh: true` by default), which is all an ephemeral preview needs. The preview `valuesObject` (image, ingress hosts, extraEnv) is unchanged and fully compatible. Previews stop being Argo Rollouts and become plain Deployments, which is simpler and appropriate for throwaway envs.
- More importantly, this drops the **last live reference to 0.1.4**, so that immutable chart tag can be deleted from the registry.

## Why it matters (the Artifact Hub error)
0.1.4 bakes in `image.tag: latest`, which `zimmertr/bluebird` never publishes, so Artifact Hub's Trivy scan of 0.1.4 fails every cycle (`image not found: zimmertr/bluebird:latest`). That default was fixed in 0.2.0 (image tag defaults to the chart appVersion), but 0.1.4 is immutable and can't be corrected. Once this merges and previews re-sync, the 0.1.4 chart tag will be deleted from Docker Hub so AH stops scanning it.

## Merge ordering
Please merge this **before** the 0.1.4 tag is deleted — my open bluebird PRs currently have preview envs pinned to 0.1.4 via this ApplicationSet, so deleting the tag first would break their sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)