### PR TITLE
feat: run stable bluebird at LOG_LEVEL=INFO

### DIFF
--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -1,4 +1,7 @@
 replicas: 3
+extraEnv:
+  - name: LOG_LEVEL
+    value: INFO
 strategy: Canary
 canary:
   dynamicStableScale: true


### PR DESCRIPTION
Counterpart to bluebird#52. Sets `LOG_LEVEL=INFO` on the stable deployment so production actually shows the new request logging.

The app image defaults to `WARNING` (kept unopinionated — verbosity is deployment config), and stable set no level, so production only ever showed uvicorn's raw access lines. `INFO` turns on the structured access log (real client IP, request summaries) that bluebird#52 ships.

Safe to merge independently: it just changes verbosity of the currently-deployed image; the new log *format* arrives once bluebird#52 is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)