### PR TITLE
fix: deploy bluebird 0.18.0 (stuck at 0.17.0 after a release race)

### DIFF
--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -24,6 +24,6 @@ generatorOptions:
 images:
 - name: zimmertr/bluebird
   newName: zimmertr/bluebird
-  newTag: 0.17.0
+  newTag: 0.18.0
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Rolls the stable app from `0.17.0` to **`0.18.0`**.

## Why
Merging the two `feat` PRs at once fired two near-simultaneous app releases. Both built fine, but their `update-manifests` steps raced (`clone → kustomize edit → push`, last-write-wins) and the **`0.17.0`** run pushed last — clobbering the tag to the *lower* version. `0.17.0` is frontend-only; **`0.18.0` is the cumulative `main` build** (frontend polish + the backend request logging from #52), so the new logging isn't live until this deploys.

Single deliberate rollout, so no experiment-Service race this time. The api-test gate still guards it.

A follow-up PR adds `concurrency` to bluebird's release workflow so this race can't recur.