### PR TITLE
fix: point bluebird probes at /healthz to quiet INFO access logs

### DIFF
--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -2,6 +2,23 @@ replicas: 3
 extraEnv:
   - name: LOG_LEVEL
     value: INFO
+# Kubelet probes hit the dedicated /healthz target, which the app access-logs
+# at TRACE only — so probe heartbeats stay out of the INFO logs while real
+# user requests to / keep logging. Requires a bluebird image that serves
+# /healthz (added in bluebird#55); older images 404 it and would fail probes.
+probes:
+  liveness:
+    httpGet:
+      path: /healthz
+      port: 8000
+  readiness:
+    httpGet:
+      path: /healthz
+      port: 8000
+  startup:
+    httpGet:
+      path: /healthz
+      port: 8000
 strategy: Canary
 canary:
   dynamicStableScale: true


### PR DESCRIPTION
## ⚠️ Merge order: bluebird PR #55 must be deployed first

`/healthz` only exists in images built from [zimmertr/bluebird#55](https://github.com/zimmertr/bluebird/pull/55). **Merging this PR while prod runs an older image makes all three probes 404 → pods restart-loop.** Sequence: merge bluebird#55 → release pipeline pushes the image and bumps `kustomization.yml` here → ArgoCD syncs → then merge this.

## Status: now optional (was: log-noise fix)

This PR was originally motivated by probe spam in the INFO logs. That's already solved on bluebird `main` by [#52](https://github.com/zimmertr/bluebird/pull/52)'s access middleware, which logs only `/api/*` and errors — probe hits to `/` produce no log lines at any level, no probe-path change required.

What this PR still buys, purely as hygiene:
- Probes stop depending on the static SPA mount serving `index.html` — `/healthz` answers from the app itself, so a probe answers "is the process healthy," not "did the frontend build ship."
- A conventional, self-describing probe target.

Fine to merge (after the image gate above) or close — no urgency either way.

## What

Overrides the three probe paths in `public/bluebird/values.yml` from `/` to `/healthz`. Only `httpGet.path` changes — timing fields come from chart defaults, verified by rendering chart 0.3.0 with this values file (initialDelay/period/failureThreshold all preserved).

## Not touched

`public/bluebird-pr/applicationset.yml` (preview envs) keeps chart-default `/` probes: previews can run branches cut before bluebird#55, which would 404 `/healthz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)