### PR TITLE
chore: trim bluebird Rollout artifact retention

### DIFF
--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -6,7 +6,7 @@ helmCharts:
   releaseName: bluebird
   repo: oci://registry-1.docker.io/zimmertr
   valuesFile: values.yml
-  version: 0.3.1
+  version: 0.4.0
 
 resources:
 - resources/namespace.yml

--- a/public/bluebird/resources/analysisTemplate.yml
+++ b/public/bluebird/resources/analysisTemplate.yml
@@ -28,6 +28,9 @@ spec:
             # Retries are governed by count/failureLimit above; a pod-level
             # retry would just hide a failed measurement.
             backoffLimit: 0
+            # Completed measurement pods self-delete after 5 minutes; prevents
+            # accumulation of old Job pods in the Argo CD UI.
+            ttlSecondsAfterFinished: 300
             template:
               metadata:
                 annotations:

--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -1,4 +1,11 @@
 replicas: 3
+# Rollout artifact retention: keep only current + 1 previous ReplicaSet, and
+# completed AnalysisRuns/Experiments per outcome (successful/failed). Reduces
+# Argo CD UI clutter without affecting deployment stability or observability.
+revisionHistoryLimit: 1
+analysis:
+  successfulRunHistoryLimit: 1
+  unsuccessfulRunHistoryLimit: 2
 extraEnv:
   - name: LOG_LEVEL
     value: INFO


### PR DESCRIPTION
## Motivation

Reduce Argo CD UI clutter by trimming artifact retention on the bluebird Rollout. Tonight's observation: ~10 old ReplicaSets, many completed AnalysisRuns/Experiments from different revisions, and dozens of old Job pods from measurements lingering in the history.

## Changes

**values.yml:** adds retention configuration  
```yaml
revisionHistoryLimit: 1  # keep current + 1 previous ReplicaSet (upstream: 10)
analysis:
  successfulRunHistoryLimit: 1    # upstream: 5
  unsuccessfulRunHistoryLimit: 2  # upstream: 5 (keep failed runs longer for abort forensics)
```

**kustomization.yml:** chart version bumped **0.3.1 → 0.4.0** to pick up the new passthrough fields from bluebird-helm#8 (feat commit triggering minor SemVer bump).

**analysisTemplate.yml:** added `ttlSecondsAfterFinished: 300` to the job spec in the `bluebird-api-test` AnalysisTemplate. Completed measurement Job pods self-delete after 5 minutes instead of accumulating indefinitely.

## ⚠️  Merge Order — CRITICAL

**DO NOT MERGE** this PR until:
1. bluebird-helm#8 ("feat: pass through revisionHistoryLimit...") is **merged** AND its chart release is **published to Docker Hub** (expected **v0.4.0**)
2. After the chart release, the bluebird-helm automation will open a redundant pin-bump PR here (e.g., `chore/bluebird-stable-chart-...`). That PR can be **closed** — this PR already pins 0.4.0.
3. The PR preview Application's pin (currently 0.1.4 in `preview/bluebird/`) is managed by its own separate auto-PR flow; leave it untouched.

Merging before the chart release will reference a non-existent image version and cause Argo CD to fail sync.

## What This Fixes

- ReplicaSet history shrinks from ~10 to 2 (current + 1 previous)  
- Completed AnalysisRuns/Experiments history shrinks from 5+ to 1 successful + 2 failed  
- Old Job pods disappear ≤5 minutes after analysis finishes  
- Argo CD UI clutter drastically reduced  

## What This Does NOT Fix

The fixed `bluebird-experiment` Service name race that can abort canaries during rapid stacked releases (incident #142) remains out of scope. Retention trimming is independent of that canary-abort mechanism; a separate fix is needed to randomize or recycle the experiment Service name on each rollout start.

## Sanity Checks

✅ All three YAML files parse correctly  
✅ Chart render with new values includes `revisionHistoryLimit: 1` and `analysis:` block at Rollout spec level  
✅ Chart render without values excludes these fields (backward compatible)  
✅ Deployment kind silently ignores analysis block (Rollout-only via template conditional)  
✅ Job ttl setting is at correct spec level (no syntax issues)  

🤖 Generated with [Claude Code](https://claude.com/claude-code)