### PR TITLE
chore: bump bluebird stable chart to 0.4.2

### DIFF
--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -6,7 +6,7 @@ helmCharts:
   releaseName: bluebird
   repo: oci://registry-1.docker.io/zimmertr
   valuesFile: values.yml
-  version: 0.4.1
+  version: 0.4.2
 
 resources:
 - resources/namespace.yml


### PR DESCRIPTION
Automated by the bluebird-helm 0.4.2 release. Rolls the stable app onto the new chart (triggers the canary rollout).