### PR TITLE
docs: document bluebird and bluebird-pr in public README

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -2,7 +2,10 @@
 
 * [Summary](#summary)
 * [Instructions](#instructions)
-  * [Kube Prometheus Stack](#kube-prometheus-stack)
+  * [Bluebird](#bluebird)
+  * [Bluebird PR](#bluebird-pr)
+  * [CertManager](#certmanager)
+  * [Personal Website](#personal-website)
 
 <hr>
 
@@ -14,15 +17,40 @@ Public is a collection of my public-facing applications.
 
 ## Instructions
 
+### Bluebird
+
+[Bluebird](https://bluebirdforecast.com) is a map-based weather window finder for hikers and mountaineers. The Kustomize project inflates the [bluebird-helm](https://artifacthub.io/packages/helm/bluebird-helm/bluebird-helm) OCI chart and deploys behind Argo Rollouts (canary) and an Istio VirtualService.
+
+The image tag in [bluebird/kustomization.yml](bluebird/kustomization.yml) is bumped automatically by the release workflow in [zimmertr/bluebird](https://github.com/zimmertr/bluebird) on every merge to `main`. Edit it by hand only to pin or roll back.
+
+1. Modify the Kustomize project as per your needs.
+
+2. Deploy to Kubernetes:
+   ```bash
+   kustomize build --enable-helm bluebird | kubectl apply -f-
+   ```
+
+### Bluebird PR
+
+Bluebird PR provides ephemeral preview environments, one per pull request in [zimmertr/bluebird](https://github.com/zimmertr/bluebird). An Argo CD `pullRequest` generator watches for PRs labeled `create pr container` and deploys the `zimmertr/bluebird-pr:pr-<number>-<sha>` image at `pr-<number>.ganymede.sol.milkyway`. Applications are pruned automatically once the PR is closed or the label is removed.
+
+Unlike the rest of `public/`, this directory has no Kustomize project. It owns its own `ApplicationSet` and `AppProject`, and is excluded from the `public/*` generator in [applicationset.yml](applicationset.yml) so the [root generators](../README.md#argo-cd) manage it directly. Nothing needs to be applied by hand once the cluster is bootstrapped.
+
+1. To apply the resources ahead of a bootstrap, or after editing them:
+   ```bash
+   kubectl apply -f bluebird-pr/appproject.yml
+   kubectl apply -f bluebird-pr/applicationset.yml
+   ```
+
 ### CertManager
 
 [Cert Manager](https://cert-manager.io/) is a tool used to request and manage X509 certificates.
 
 1. Modify the Kustomize project as per your needs.
 
-3. Deploy to Kubernetes:
+2. Deploy to Kubernetes:
    ```bash
-   kustomize build --enable-helm certificate-manager | kubectl apply -f-
+   kustomize build --enable-helm cert-manager | kubectl apply -f-
    ```
 
 ### Personal Website
@@ -31,8 +59,7 @@ Public is a collection of my public-facing applications.
 
 1. Modify the Kustomize project as per your needs.
 
-3. Deploy to Kubernetes:
+2. Deploy to Kubernetes:
    ```bash
    kustomize build --enable-helm personal-website | kubectl apply -f-
    ```
-


### PR DESCRIPTION
## Summary

`public/README.md` documented only CertManager and Personal Website, while its table of contents pointed at a **Kube Prometheus Stack** section that does not exist in the file. Two applications under `public/` were undocumented.

- **Bluebird** — production [bluebirdforecast.com](https://bluebirdforecast.com); Kustomize project inflating the `bluebird-helm` OCI chart. Notes that the image tag is bumped automatically by the bluebird release workflow, so hand edits are for pinning/rollback only.
- **Bluebird PR** — ephemeral per-PR preview envs. Documented at more length because it is the only directory under `public/` that is *not* a Kustomize project: it owns its own `ApplicationSet` + `AppProject` and is excluded from the `public/*` git generator in `applicationset.yml`, so the repo-root generators manage it directly. The usual `kustomize build` instruction does not apply there.

Sections follow the existing house style in `media/README.md` and `argo/README.md`, ordered alphabetically, with the TOC rebuilt to match.

## Drive-by fixes

- The CertManager command referenced `certificate-manager`; the directory is `cert-manager`.
- Existing sections numbered their steps `1.` then `3.`.

## Verification

Every documented command was run against this branch:

```
bluebird           OK
cert-manager       OK
personal-website   OK
```

(`kustomize build --enable-helm <dir>`, from `public/`.) Docs-only change; no manifests or cluster state touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)