### PR TITLE
ci: let Renovate track the check's own tooling, and make the check prove it works

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,16 @@
   ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Tool versions pinned in workflow env vars, tagged with a `# renovate:` annotation. Actions and setup-* inputs are found by the built-in manager; a hand-rolled download URL is not.",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+\\w+: [\"']?(?<currentValue>[^\"'\\s]+)"
+      ]
+    }
+  ],
   "packageRules": [
     {
       "description": "Automerge patch updates",

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,8 +31,15 @@ jobs:
           version: v3.21.3
 
       - name: Install kustomize
+        env:
+          # There's no setup-kustomize action pinned here, so the version lives in
+          # an env var with the annotation Renovate's customManager looks for.
+          # Without it a hand-rolled download URL is invisible to Renovate and the
+          # pin rots silently — this sat at 5.7.1 while upstream reached 5.8.1.
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/v(?<version>.+)$
+          KUSTOMIZE_VERSION: 5.8.1
         run: |
-          curl -sSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.7.1/kustomize_v5.7.1_linux_amd64.tar.gz" \
+          curl -sSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
             | sudo tar xz -C /usr/local/bin
           kustomize version
 
@@ -92,6 +99,17 @@ jobs:
               dir="$(dirname "$dir")"
             done
           done < changed.txt
+
+          # This workflow is the only thing standing between a bad manifest and a
+          # failed Argo sync, and Renovate keeps bumping the tools it runs. A PR
+          # that only edits this file has no kustomization ancestor, so it would
+          # otherwise pass on an empty target list — green without rendering
+          # anything, which is exactly how a broken helm/kustomize bump would land.
+          # Render one real app so the check has to prove it still works.
+          if grep -q '^\.github/workflows/pr\.yml$' changed.txt; then
+            echo "Workflow changed — adding public/bluebird as a canary target."
+            targets="$(printf '%s\n%s' "$targets" "public/bluebird")"
+          fi
 
           targets="$(printf '%s' "$targets" | grep -v '^$' | sort -u || true)"
           if [ -z "$targets" ]; then


### PR DESCRIPTION
Follow-up to #393. Two coupled gaps in the new `Validate manifests` check.

## 1. Renovate can't see kustomize

`actions/checkout`, `azure/setup-helm`, and the `version:` input to setup-helm are all found by Renovate's built-in `github-actions` manager, which is why #395–#398 appeared. **kustomize is not**: it's installed from a hand-rolled `curl` URL, which no manager recognises. It has been pinned at `5.7.1` while upstream reached `5.8.1`, and nothing would ever have told us.

Fixed by moving the version into an env var carrying the standard `# renovate:` annotation, plus the `customManagers` entry that reads it. Bumped to `5.8.1` in the same change.

Verified rather than assumed:
- `renovate-config-validator --strict` against the repo config: passes (this also confirms `managerFilePatterns`, which replaced `fileMatch`, is the right key for current Renovate)
- Ran the `matchStrings` regex against `pr.yml` under Node: extracts `{datasource: github-releases, depName: kubernetes-sigs/kustomize, extractVersion: ^kustomize/v(?<version>.+)$, currentValue: 5.8.1}`, and the file pattern matches the workflow path
- kustomize `5.8.1` + helm `3.21.3` still render `public/bluebird` to 9 documents

## 2. The check couldn't catch a bad bump anyway

A PR that only edits `.github/workflows/pr.yml` has no kustomization ancestor, so the render step short-circuited to "No kustomization affected" and went green **without rendering anything**. That is exactly the shape of a Renovate tooling bump, so a helm or kustomize upgrade that broke rendering would have merged clean and then failed every subsequent bump PR.

The render step now adds `public/bluebird` as a canary target whenever this workflow changes, so the check has to prove the toolchain still works. **This PR is its own test case** — it edits `pr.yml`, so the render must run here.

## Note on merge policy

Renovate automerges minor/patch after a 7-day cooldown and holds majors for review, which is the desired behaviour and needs no change. The open #398 (`helm` v3 → v4) is a major and correctly waiting; with this PR merged, it would at least be rendered before anyone approves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)