### PR TITLE
ci: hold bluebird stable chart bumps whose rendered manifests change

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
   # failed sync rather than a failed build. This job is what makes the
   # automated bump PRs (bluebird image tag, bluebird-helm chart versions) worth
   # routing through a PR at all: `gh pr merge --auto` has something to wait on.
+  # For the prod chart bump it is also the review gate — see the render-diff
+  # step at the end of this job.
   validate:
     name: Validate manifests
     runs-on: ubuntu-latest
@@ -129,3 +131,27 @@ jobs:
             fi
           done
           exit $rc
+
+      # The one bump PR that must not always self-merge: a chart change can
+      # render fine yet still change prod (helm silently ignores values the
+      # chart stopped reading). A render diff vs origin/main (what Argo runs)
+      # fails this required check and with it the armed auto-merge. The branch
+      # guard exists because every other PR is supposed to change the render.
+      # Labels are stripped by yq path, not grep, so a version label leaking
+      # into matchLabels still surfaces and holds.
+      - name: Gate stable chart bumps on an inert render
+        if: github.head_ref == 'chore/bluebird-stable-chart'
+        run: |
+          strip() { yq e 'del(.metadata.labels."helm.sh/chart", .metadata.labels."app.kubernetes.io/version")' -; }
+          kustomize build --enable-helm public/bluebird | strip > /tmp/head.yaml
+          git worktree add -q /tmp/deployed origin/main
+          kustomize build --enable-helm /tmp/deployed/public/bluebird | strip > /tmp/deployed.yaml
+          if diff -u /tmp/deployed.yaml /tmp/head.yaml > /tmp/render.diff; then
+            echo "Rendered prod manifests unchanged (version labels aside) — inert, safe to self-merge."
+            exit 0
+          fi
+          echo '::group::rendered prod diff (deployed -> this PR)'
+          cat /tmp/render.diff
+          echo '::endgroup::'
+          echo "::error::This chart bump changes prod's rendered manifests, so it is held: the failing check blocks any merge of this PR (required checks bind admins here too). Review the diff in the step log, then ship the same version bump in a normal PR together with whatever values.yml change it needs — human branches skip this gate — and close this one. Don't push fixes to this branch: releases force-push over it."
+          exit 1


### PR DESCRIPTION
Replaces the abandoned bash classifier from zimmertr/bluebird-helm#17 with ~15 lines inside the check that already gates these PRs.

## What

A branch-guarded step at the end of `Validate manifests`, firing only on PRs from `chore/bluebird-stable-chart` (the bot branch bluebird-helm force-pushes on every chart release):

- Render `public/bluebird` twice: at the PR, and at `origin/main` via `git worktree` — main *is* the deployed state, so the diff prices the PR's true net effect even when it spans several chart releases.
- Strip the two labels the chart stamps from its own version (`helm.sh/chart`, `app.kubernetes.io/version`) — deleted by **yq path**, not line grep, so a version label ever leaking into `matchLabels`/selectors would still surface and hold.
- Identical → pass; the auto-merge bluebird-helm armed completes on its own. Different → the step prints the rendered diff and fails the required check, which blocks the auto-merge (GitHub disarms it and notifies the arming account). No API calls, no state; the job keeps `permissions: contents: read`.

Image bumps (`chore/bluebird-image`), preview chart bumps, and hand-made config PRs are *supposed* to change the render — the branch guard keeps them all ungated.

## Why render-diff instead of classifying changed chart files

It tests inertness directly instead of inferring it. The dangerous class — a chart change that renders successfully but silently ignores `values.yml` keys — is invisible to a file list but shows up here as, say, tuned resources reverting to chart defaults. The failing step's log then contains exactly the review material a human needs: the prod object diff.

## The held flow

`enforce_admins` is on, so a failing required check blocks any merge of the held PR, including admin bypass. That's deliberate and fine: the intended path is a **normal PR** carrying the same version bump *plus* whatever `values.yml` change the new chart needs, atomically — something the bot PR could never do. Human branches skip the gate. The step's failure message says all of this. Don't push fixes onto the bot branch; releases force-push over it.

## Verification

- `actionlint` clean.
- The gate's shell **extracted verbatim** from this file and run in Docker (alpine/k8s) against real published charts, in a synthetic repo whose `origin/main` plays "deployed":

| deployed | head | expectation | result |
| --- | --- | --- | --- |
| 0.4.9 | 0.4.10 | inert (appVersion-only release) | ✅ exit 0 |
| 0.2.0 | 0.4.10 | held, non-empty rendered diff | ✅ exit 1, 14-line diff |
| 0.4.9 | 9.9.9 (unpublished) | fail closed | ✅ exit 1 |

- This PR itself exercises the render path: changing `pr.yml` adds `public/bluebird` as a canary target. The gate step is correctly **skipped** here (branch guard).
- After merge: a live throwaway PR from the real bot branch will confirm both verdicts end-to-end, and the next routine chart release is a free test of the inert path.

`yq` is not installed by this workflow — it's preinstalled on `ubuntu-latest` runners (mikefarah v4).

Docs: the CI/CD flow description lives in `bluebird/docs/CICD.md`; a companion PR there replaces the bash-design text that was merged prematurely in zimmertr/bluebird#149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)