### PR TITLE
chore: bump bluebird image to 0.29.6

### DIFF
--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -24,6 +24,6 @@ generatorOptions:
 images:
 - name: zimmertr/bluebird
   newName: zimmertr/bluebird
-  newTag: 0.29.5
+  newTag: 0.29.6
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Automated by the bluebird 0.29.6 release. Rolls the stable app onto the freshly published `zimmertr/bluebird:0.29.6` (triggers the canary rollout).

- Release: https://github.com/zimmertr/bluebird/releases/tag/v0.29.6