### PR TITLE
fix(bluebird): bump stable chart to 0.5.0 to restore /healthz probes

### DIFF
--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -6,7 +6,7 @@ helmCharts:
   releaseName: bluebird
   repo: oci://registry-1.docker.io/zimmertr
   valuesFile: values.yml
-  version: 0.4.12
+  version: 0.5.0
 
 resources:
 - resources/namespace.yml


### PR DESCRIPTION
Lands the bluebird-helm 0.5.0 chart that #410 was written against. Supersedes #414, which the render gate held on a stale render (see below).

## Why this is a `fix`

#410 removed the explicit `probes:` block from `values.yml`, on the premise that the chart now defaults all three probes to `/healthz`. That default arrived in [bluebird-helm 0.5.0](https://github.com/zimmertr/bluebird-helm/pull/20), which was not yet pinned here. So `main` kept rendering against 0.4.12, whose default is `GET /`, and prod quietly lost the fix from #374: probe heartbeats are back in the INFO access logs.

The rendered probe paths on `main` today:

```
164:              path: /
175:              path: /
182:              path: /
```

## Why the automated bump (#414) could not land this

bluebird-helm 0.5.0 replaced the `bluebird.isRollout` helper, which inferred a Rollout from `strategy: Canary`, with an explicit `useRollout` value that defaults to `false`. #414 and its gate ran at 02:08:03Z. #410, which adds `useRollout: true`, merged at 02:10:28Z. So the gate rendered 0.5.0 against values that had not been updated yet and correctly reported a `Rollout` to `Deployment` downgrade. That diff described a state of `main` that existed for 145 seconds, and #414 cannot be refreshed because releases force-push over its branch.

## Verified render

`kustomize build --enable-helm` on `main` vs this branch, with the gate's own label-strip applied. Both sides render 253 lines, the Rollout and canary Service are intact, and the entire diff is the intended probe change:

```diff
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
```

...and the same for `readinessProbe` and `startupProbe`. This is a pod-template change, so it triggers a canary rollout through the #410 steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)