### PR TITLE
fix(bluebird): restore the canary trafficRouting block

### DIFF
--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -11,18 +11,8 @@ extraEnv:
 
 useRollout: true
 strategy: Canary
+
 canary:
-  # Required by the setCanaryScale step below: without a traffic router Argo
-  # derives the canary's traffic share from its replica count, which is the
-  # dial setCanaryScale overrides, so the controller rejects the whole spec
-  # (InvalidSpec, Rollout never progresses). It is also the only thing that
-  # ever moves the weights on the chart's bluebird-stable route.
-  trafficRouting:
-    istio:
-      virtualService:
-        name: bluebird
-        routes:
-          - bluebird-stable
   steps:
     - setCanaryScale:
         replicas: 1
@@ -39,6 +29,12 @@ canary:
     - analysis:
         templates:
           - templateName: api-test
+  trafficRouting:
+    istio:
+      virtualService:
+        name: bluebird
+        routes:
+          - bluebird-stable
 
 ingress:
   enabled: true

--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -12,6 +12,17 @@ extraEnv:
 useRollout: true
 strategy: Canary
 canary:
+  # Required by the setCanaryScale step below: without a traffic router Argo
+  # derives the canary's traffic share from its replica count, which is the
+  # dial setCanaryScale overrides, so the controller rejects the whole spec
+  # (InvalidSpec, Rollout never progresses). It is also the only thing that
+  # ever moves the weights on the chart's bluebird-stable route.
+  trafficRouting:
+    istio:
+      virtualService:
+        name: bluebird
+        routes:
+          - bluebird-stable
   steps:
     - setCanaryScale:
         replicas: 1


### PR DESCRIPTION
## What is broken

`Rollout/bluebird` has been **Degraded** since #410:

```
InvalidSpec: The Rollout "bluebird" is invalid: spec.strategy.trafficRouting:
Required value: SetCanaryScale requires TrafficRouting to be set
```

Release `0.30.0` is parked at `currentStepIndex: 0` and cannot promote. The site stays up on `0.29.6` because the VirtualService is still 100% stable, so there is no user-visible impact, but no release can ship until this lands.

## Why

Argo Rollouts rejects a canary spec that uses `setCanaryScale` without `trafficRouting`. Without a router, the canary's traffic share is derived from its replica count, and that is precisely the dial `setCanaryScale` overrides. Rather than silently pick one, the controller refuses the spec.

The block was removed in 6d19ef5 ("deslop"), a commit intended to trim comments. It deleted the comments and the config they documented in the same hunk, while keeping the `setCanaryScale` step that depends on it.

## What this changes

Restores `trafficRouting` only:

```yaml
canary:
  trafficRouting:
    istio:
      virtualService:
        name: bluebird
        routes:
          - bluebird-stable
```

The rest of what 6d19ef5 removed (`dynamicStableScale`, `setCanaryScale: {matchTrafficWeight: true}`, the `setWeight`/`pause` ladder) deliberately stays out. The current strategy gates one canary pod at 0% user traffic behind two blocking analyses and then promotes, which is the intended shape.

Worth noting `trafficRouting` is not only about passing validation here: it is the only thing that ever moves the weights on the chart's `bluebird-stable` route. Without it the canary sat at weight 0 for the whole rollout and would have been promoted having served no user traffic.

## Verification

- Rendered with `kustomize build --enable-helm` against chart `0.5.0`: `trafficRouting` lands under `spec.strategy.canary`, and `routes: [bluebird-stable]` matches the rendered VirtualService's only named route (`canaryService`/`stableService` already match its two destinations).
- `kubectl apply --dry-run=server` returns the field un-pruned, which is the failure mode #410 hit with `progressDeadlineAbort`.
- Post-merge check is the live rollout: `0.30.0` should clear both analyses and scale the canary RS to 3 on promotion.

Docs for the new flow are updated in zimmertr/bluebird (`docs/CICD.md`), which still describes the pre-#410 Experiment gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)