### PR TITLE
fix(bluebird): drop the AnalysisRun history limits

### DIFF
--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -1,9 +1,6 @@
 replicas: 3
 
 revisionHistoryLimit: 1
-analysis:
-  successfulRunHistoryLimit: 1
-  unsuccessfulRunHistoryLimit: 2
 
 extraEnv:
   - name: LOG_LEVEL


### PR DESCRIPTION
## The symptom

After the 0.30.1 release, `kubectl get analysisrun -n bluebird-system` showed exactly one run:

```
NAME                      STEP   PHASE        CREATED
bluebird-df4f8695f-86-1   1      Successful   2026-07-28T02:45:02Z
```

Step 1 is `version-check`. No sign of the `api-test` gate, which reads as "the functional gate never ran".

## What actually happened

It ran, passed, and was garbage collected 0.2 s later:

```
02:45:02  Created AnalysisRun for step '2'   analysisrun=bluebird-df4f8695f-86-2  metric=api-test
02:45:15  Metric 'api-test' Completed. Result: Successful
02:45:15  Trying to cleanup analysis run 'bluebird-df4f8695f-86-2'
02:45:15  analysis run deleted
```

The Rollout promoted cleanly (`Rollout step 3/3 completed (analysis)`). `successfulRunHistoryLimit` counts AnalysisRuns **per Rollout, not per release**, and the canary has two analysis steps, so at 1 the pair went over the limit the moment the second gate completed and one of the two was deleted on the spot. Revision 85 did the same thing.

Which one lost was arbitrary. In argo-rollouts v1.9.1, `FilterAnalysisRunsToDelete` sorts candidates with `sort.Sort(sort.Reverse(AnalysisRunByCreationTimestamp(ars)))`, and that comparator is a bare `CreationTimestamp.Before()` with no tiebreak. Kubernetes stamps are second-granularity and both runs of a release share one, so the comparison ties and a non-stable sort resolves it however it likes. `api-test` losing twice was coincidence.

## Why drop the limits rather than raise them

The first version of this PR set `successfulRunHistoryLimit: 2`, one per analysis step. That works, but it is a number that has to be kept in sync with the length of the step list, and nothing enforces that. Adding a third analysis step would silently reintroduce exactly this bug.

The limits turn out not to be carrying their weight at all:

- **`revisionHistoryLimit: 1` already bounds AnalysisRun retention.** A run whose ReplicaSet is gone, or whose ReplicaSet is terminating, is deleted *unconditionally* — before either count limit is consulted (`FilterAnalysisRunsToDelete`, `utils/analysis/filter.go`). Keeping one old ReplicaSet therefore caps runs at the two most recent releases regardless of what the counts say.
- **The controller defaults sit above that cap**, so they never bind: 5 successful and 5 unsuccessful (`DefaultAnalysisRunSuccessfulHistoryLimit`, `utils/defaults/defaults.go:20-22`). Both getters are nil-safe at both levels, so omitting the whole `analysis:` block is fine.

So the counts were only ever capable of doing harm here, never work. Removing them leaves one retention knob instead of three, and it self-adjusts if the step list changes.

**Net effect is more history than either 1 or 2 would have given:** both gates of the current release *and* both of the previous one. `successfulRunHistoryLimit: 2` would have kept only the current release's pair.

## Scope

`unsuccessfulRunHistoryLimit: 2` was already adequate, so a **failing** gate was always retained. What was lost is the audit trail for releases that *passed*. Diagnosis of a failed canary was never affected.

## Verification

The chart does not define `analysis:` at all (it is opt-in), so dropping the block from `values.yml` makes `.Values.analysis` nil and the chart's `{{- if and $isRollout .Values.analysis }}` omits the field entirely. Rendered the same way CI does:

```
$ kustomize build --enable-helm public/bluebird | grep -n 'analysis:\|HistoryLimit'
124:  revisionHistoryLimit: 1
142:      - analysis:      # canary steps, unrelated field
150:      - analysis:
```

`spec.analysis` is absent and `revisionHistoryLimit: 1` is untouched. Values-only change on a human branch, so the stable-chart render-diff gate does not apply.

End-to-end proof is the next release: `kubectl get analysisrun -n bluebird-system` should show both `-N-1` and `-N-2` after it promotes.

Companion docs PR: zimmertr/bluebird#156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)