### PR TITLE
chore: bump bluebird preview chart to 0.6.7

### DIFF
--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -29,7 +29,7 @@ spec:
       source:
         repoURL: oci://registry-1.docker.io/zimmertr/bluebird-helm
         chart: bluebird-helm
-        targetRevision: 0.6.6
+        targetRevision: 0.6.7
         helm:
           releaseName: "bluebird-pr-{{ .number }}"
           valuesObject:


### PR DESCRIPTION
Automated by the bluebird-helm 0.6.7 release. Points the per-PR preview ApplicationSet at the new chart.