### PR TITLE
feat(bluebird): enable autoscaling, PDB and node spread

### DIFF
--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -1,4 +1,23 @@
-replicas: 3
+# No `replicas` here on purpose: the chart omits spec.replicas entirely while
+# autoscaling is enabled, so Argo CD cannot fight the HPA over it, and
+# autoscaling.minReplicas below is the floor instead.
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+
+# Keeps 2 pods through a node drain. PDB percentages round UP, so minAvailable
+# 50% requires 2 of 3 to survive where maxUnavailable 50% would permit 2
+# disruptions and leave 1.
+podDisruptionBudget:
+  enabled: true
+
+# One pod per worker node while nodes last, collapsing gracefully when they do
+# not: 3 nodes gives [1,1,1], 2 gives [2,1] with nothing Pending, 1 gives [3].
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
 
 revisionHistoryLimit: 1
 


### PR DESCRIPTION
> [!WARNING]
> **Draft on purpose. Do not merge until the chart version in `public/bluebird/kustomization.yml` has been bumped past the release containing [bluebird-helm#48](https://github.com/zimmertr/bluebird-helm/pull/48).**
>
> This PR removes `replicas: 3`. Against the currently pinned chart `0.7.1`, which has no `autoscaling` key, Helm would ignore the new values and `replicas` would fall back to the chart default of **1** — scaling production from three pods to one. No CI check catches this; the ordering is the safeguard.

Production half of [bluebird#130](https://github.com/zimmertr/bluebird/issues/130).

## Changes

- **`replicas: 3` removed.** The chart omits `spec.replicas` from the workload entirely while autoscaling is on, so Argo CD auto-sync cannot fight the HPA over it. `autoscaling.minReplicas: 3` becomes the floor, preserving current behaviour.
- **HPA enabled**, 3 to 10, scaling on CPU at 70% of the new `250m` request. Prod's canary already opens with `setCanaryScale: {replicas: 1}`, which is the documented decoupling of canary replica count from HPA-driven scaling.
- **PDB enabled** at `minAvailable: 50%`, keeping 2 pods through a node drain.
- **Topology spread** at `maxSkew: 1` over `kubernetes.io/hostname`.

Resources and the hardened securityContext arrive from the chart defaults and need no override here.

## Verification

Rendered with the PR-48 chart and applied against the live cluster with `--dry-run=server`:

```
poddisruptionbudget.policy/bluebird     created (server dry run)
horizontalpodautoscaler.autoscaling/bluebird created (server dry run)
rollout.argoproj.io/bluebird            configured (server dry run)
service/bluebird, service/bluebird-canary configured (server dry run)
gateway / virtualservice                configured (server dry run)
```

`spec.replicas` confirmed absent from the rendered Rollout, and the canary's `setCanaryScale` step is preserved.

## After merge

Watch the canary complete Healthy with the HPA live — argo-rollouts [#3848](https://github.com/argoproj/argo-rollouts/issues/3848) / [#3849](https://github.com/argoproj/argo-rollouts/issues/3849) describe HPA scaling mid-canary wedging a rollout in `Progressing`. The `setCanaryScale` step should prevent it, but it is worth confirming on the first real rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)