### PR TITLE
fix(bluebird): honor node taints when computing topology spread skew

### DIFF
--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -14,10 +14,22 @@ podDisruptionBudget:
 
 # One pod per worker node while nodes last, collapsing gracefully when they do
 # not: 3 nodes gives [1,1,1], 2 gives [2,1] with nothing Pending, 1 gives [3].
+#
+# nodeTaintsPolicy is load-bearing, not decoration. It defaults to Ignore,
+# which makes EVERY node an eligible domain -- including the three
+# control-plane nodes this pod has no toleration for. Skew is measured against
+# the global minimum across eligible domains, so those permanently empty
+# domains pin that minimum at 0, and maxSkew 1 then allows at most one pod per
+# worker: a hard ceiling of 3 pods cluster-wide, below the 6 a canary needs at
+# its last step. Honor counts only nodes the pod could actually land on, so the
+# domain set is the 3 workers, the minimum is 1, and [2,2,2] schedules. It also
+# keeps `kubectl drain` working, since a cordoned node carries the
+# unschedulable taint and would otherwise become one more empty domain.
 topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: DoNotSchedule
+    nodeTaintsPolicy: Honor
 
 revisionHistoryLimit: 1
 


### PR DESCRIPTION
Fixes the wedged production rollout from [bluebird#130](https://github.com/zimmertr/bluebird/issues/130). The node spread added in #492 is one field short, and that field is load-bearing.

## Symptom

`bluebird` has been stuck in `Progressing` at its final canary step since the 0.41.0 rollout, with two pods `Pending`:

```
bluebird-7fd8fcc9b-ckxjf   k8s-node-2   Running    (stable)
bluebird-7fd8fcc9b-fh27t   k8s-node-1   Running    (stable)
bluebird-7fd8fcc9b-tz24v   k8s-node-3   Running    (stable)
bluebird-f9c59db89-hbbcr   k8s-node-2   Running    (canary)
bluebird-f9c59db89-dvw64   <none>       Pending    (canary)
bluebird-f9c59db89-vq84b   <none>       Pending    (canary)
```

```
FailedScheduling  0/6 nodes are available:
  3 node(s) didn't match pod topology spread constraints,
  3 node(s) had untolerated taint(s).
```

The site itself never went down. Stable held 100% of the traffic weight the whole time, `/healthz` is 200 and `/api/version` reports 0.41.0. Both canary analyses (`version-check`, `api-test`) passed. The only thing broken is that the rollout can never finish, so it also can never promote or roll back.

## Cause

`nodeTaintsPolicy` was left unset. [Upstream](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/): *"If this value is null, the behavior is equivalent to the Ignore policy"*, and Ignore means *"node taints are ignored. All nodes are included."*

So all six nodes are eligible topology domains, including `k8s-cp-1/2/3`, which carry `node-role.kubernetes.io/control-plane:NoSchedule` and which bluebird does not tolerate. Skew is measured against the *global minimum* across eligible domains, and those three domains sit at 0 forever.

Counts at the time of the failure were `node-1: 1, node-2: 2, node-3: 1, cp-1/2/3: 0`, so global minimum `= 0`:

| candidate | resulting count | skew vs. min 0 | verdict |
|---|---|---|---|
| `k8s-node-1` | 2 | 2 | rejected (> maxSkew 1) |
| `k8s-node-2` | 3 | 3 | rejected |
| `k8s-node-3` | 2 | 2 | rejected |
| `k8s-cp-1/2/3` | n/a | n/a | rejected (untolerated taint) |

That reproduces the scheduler message exactly, including its `3 + 3` split.

It is also the counter-check that rules out every other explanation: if the domain set were only the three workers, the minimum would be 1, `k8s-node-1` would score `1 + 1 - 1 = 1`, and it would have been schedulable. It was not, so a zero-count eligible domain must exist, and only the control-plane nodes can supply one.

**The practical effect is that `maxSkew: 1` allowed at most one bluebird pod per worker: a hard ceiling of 3 pods cluster-wide.** A canary needs 6 at its last step (3 stable + 3 canary), so the ceiling was hit on the very first rollout under the new values. The HPA could not have scaled past 3 either.

The `[1,1,1] / [2,1] / [3]` reasoning in #492 was right about domain *collapse*; it just did not account for domains that are eligible on paper and unschedulable in practice.

## Fix

```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
    nodeTaintsPolicy: Honor
```

Honor counts only nodes whose taints the pod tolerates, so the domain set becomes the three workers, the minimum becomes 1, and the canary peak of `[2,2,2]` schedules with skew 0.

It fixes a second latent case for the same reason: a cordoned node carries `node.kubernetes.io/unschedulable:NoSchedule`, so under Ignore **`kubectl drain` of any worker would have wedged the app too**, exactly when the PDB is supposed to be protecting it.

## Why `DoNotSchedule` stays

Softening to `ScheduleAnyway` would also unwedge this, but it trades away the guarantee the constraint exists for: that a single node loss cannot take all three replicas. A hard constraint is only a hazard if a node runs out of room, and these do not. Workers are `9950m` allocatable each and currently sit at 5%, 11% and 10% CPU requested. At `maxReplicas: 10` a canary peaks at 20 pods = 5 cores of requests against ~30 allocatable, spreading `[7,7,6]`, skew 1. Keeping the hard guarantee costs nothing here, so this PR fixes the domain set rather than weakening the constraint.

## Verification

- `kustomize build --enable-helm` render diff against `main` is exactly one added line, `nodeTaintsPolicy: Honor`, in the Rollout pod spec. No other drift.
- Chart-side it needs no release: `workload.yaml` passes each constraint through verbatim and only injects `labelSelector`.
- `kubectl apply --dry-run=server` against the live cluster validates all ten rendered resources, including the Rollout against the real CRD.

## After merge

The pod template changes, so Argo Rollouts starts a fresh revision and re-runs both analysis steps rather than resuming the wedged one. Expected end state is three pods on the new revision, one per worker, with the HPA finally able to read CPU utilization (it currently errors `missing request for cpu`, because the stable ReplicaSet predates the resource requests from #492).

## Follow-up worth considering

`bluebird-helm`'s `values.yaml` documents this constraint with the same incomplete reasoning, so the next consumer to copy it inherits the trap. A docs-only chart PR would be worth raising, deliberately left out of here to keep the production fix independent of a chart release.
