### PR TITLE
chore: bump bluebird stable chart to 0.8.6

### DIFF
--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -6,7 +6,7 @@ helmCharts:
   releaseName: bluebird
   repo: oci://registry-1.docker.io/zimmertr
   valuesFile: values.yml
-  version: 0.8.5
+  version: 0.8.6
 
 resources:
 - resources/namespace.yml


### PR DESCRIPTION
Automated by the bluebird-helm 0.8.6 release. Rolls the stable app onto the new chart (triggers the canary rollout).