### PR TITLE
fix: drop the render-diff gate on stable chart bumps

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,15 +18,13 @@ jobs:
   # failed sync rather than a failed build. This job is what makes the
   # automated bump PRs (bluebird image tag, bluebird-helm chart versions) worth
   # routing through a PR at all: `gh pr merge --auto` has something to wait on.
-  # For the prod chart bump it is also the review gate — see the render-diff
-  # step at the end of this job.
   validate:
     name: Validate manifests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0  # need the merge base to diff against
+          fetch-depth: 0  # need the PR's base commit to list changed files against
 
       - uses: azure/setup-helm@v5
         with:
@@ -119,6 +117,23 @@ jobs:
             exit 0
           fi
 
+          # A chart bump's real hazard is not that it changes the render — an
+          # intended default change is supposed to — but that helm SILENTLY
+          # IGNORES a value the chart stopped reading, so this repo keeps
+          # pinning a setting it has already lost. bluebird-helm answers that
+          # at its own boundary: its values.schema.json sets
+          # `additionalProperties: false`, so `helm template` (what kustomize
+          # runs below, and what Argo CD runs on sync) exits non-zero on a key
+          # the chart does not read, and this step goes red.
+          #
+          # A render-diff gate used to stand here instead, holding any stable
+          # chart bump whose prod render moved. It keyed on the branch name, so
+          # its only escape was reopening the identical one-line diff from a
+          # differently-named branch (PR #494 -> #497, byte-identical), and the
+          # fixed release branch meant one held version blocked every later one:
+          # it caught two intended chart changes in 30 bumps and left prod eight
+          # chart versions behind, while the silent-drop case above could still
+          # pass it as a plausible-looking diff.
           rc=0
           for t in $targets; do
             echo "::group::kustomize build $t"
@@ -131,27 +146,3 @@ jobs:
             fi
           done
           exit $rc
-
-      # The one bump PR that must not always self-merge: a chart change can
-      # render fine yet still change prod (helm silently ignores values the
-      # chart stopped reading). A render diff vs origin/main (what Argo runs)
-      # fails this required check and with it the armed auto-merge. The branch
-      # guard exists because every other PR is supposed to change the render.
-      # Labels are stripped by yq path, not grep, so a version label leaking
-      # into matchLabels still surfaces and holds.
-      - name: Gate stable chart bumps on an inert render
-        if: github.head_ref == 'chore/bluebird-stable-chart'
-        run: |
-          strip() { yq e 'del(.metadata.labels."helm.sh/chart", .metadata.labels."app.kubernetes.io/version")' -; }
-          kustomize build --enable-helm public/bluebird | strip > /tmp/head.yaml
-          git worktree add -q /tmp/deployed origin/main
-          kustomize build --enable-helm /tmp/deployed/public/bluebird | strip > /tmp/deployed.yaml
-          if diff -u /tmp/deployed.yaml /tmp/head.yaml > /tmp/render.diff; then
-            echo "Rendered prod manifests unchanged (version labels aside) — inert, safe to self-merge."
-            exit 0
-          fi
-          echo '::group::rendered prod diff (deployed -> this PR)'
-          cat /tmp/render.diff
-          echo '::endgroup::'
-          echo "::error::This chart bump changes prod's rendered manifests, so it is held: the failing check blocks any merge of this PR (required checks bind admins here too). Review the diff in the step log, then ship the same version bump in a normal PR together with whatever values.yml change it needs — human branches skip this gate — and close this one. Don't push fixes to this branch: releases force-push over it."
-          exit 1


### PR DESCRIPTION
The gate held any `chore/bluebird-stable-chart` PR whose rendered prod manifests moved. It asks the wrong question.

**It fires on intended changes.** `public/bluebird/values.yml` pins almost nothing, so every deliberate chart-default change moves the render. PR #534 is held right now because chart 0.9.0 raised the default memory request 128Mi to 256Mi for the wildfire snapshot (bluebird-helm#59), which is exactly what that release was for.

**Its only escape is the branch name.** The step keys on `github.head_ref`, so the documented remedy is to reopen the same one-line diff from a differently-named branch. That is what happened to PR #494: closed, then #497 `chartbump` shipped a byte-identical diff. No new information entered the system.

**It compounds.** The release branch is fixed and force-pushed, and the workflow says not to push fixes to it, so one held version blocks every later one. Prod is on chart 0.8.12 while 0.9.7 is published, eight versions behind.

**And it misses what it was written for.** The real hazard its comment names is that helm silently ignores a value the chart stopped reading, so this repo keeps pinning a setting it has already lost. In a render diff that appears as one more plausible-looking hunk among the intended ones.

### What replaces it

zimmertr/bluebird-helm#69 gives the chart a `values.schema.json` with `additionalProperties: false`, so an unrecognized key fails `helm template` outright:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
bluebird-helm:
- (root): Additional property revisionHistoryLimits is not allowed
```

`kustomize build --enable-helm` shells out to `helm template`, so the existing **Render affected kustomizations** step catches that on every PR and every branch, not just the bot's. Argo CD renders the same way, so it cannot reach a sync either. That PR also asserts the refusal in its own CI, so a schema that stops matching the templates fails there.

Merge order does not matter: this repo pins a chart version, and the schema starts guarding as soon as prod moves onto a chart that ships it.

### After this merges

Re-run `Validate manifests` on #534 so prod catches up to 0.9.7. The memory raise is intended, and it rolls out as a canary.

Docs for this flow live in zimmertr/bluebird `docs/CICD.md`, updated in a paired PR there.
