### PR TITLE
fix: post destination_types from the api-test canary probe

### DIFF
--- a/public/bluebird/resources/analysisTemplate-apiTest.yml
+++ b/public/bluebird/resources/analysisTemplate-apiTest.yml
@@ -14,7 +14,7 @@ spec:
           url: http://bluebird-canary.bluebird-system.svc.cluster.local:8000/api/analyze
           timeoutSeconds: 120
           jsonBody:
-            destination_type: peak
+            destination_types: [peak]
             forecast_mode: current
             limit: 3
             polygon:


### PR DESCRIPTION
Fixes the canary gate that has aborted every rollout since 0.47.0.

## What was wrong

The `api-test` probe posted `destination_type: peak`. bluebird [#229](https://github.com/zimmertr/bluebird/pull/229) renamed that field and made it a set:

```diff
-    destination_type: DestinationType = Field(...)
+    destination_types: list[DestinationType] = Field(default_factory=list, ...)
```

Pydantic ignores unknown fields, so the singular key was dropped, `destination_types` fell back to its empty default, and a request with no types and no `custom_destinations` has nothing to analyze:

```
{"detail":"Nothing to analyze: send destination_types with a polygon, custom_destinations, or both."}
HTTP 400
```

Argo reports only the status code, which is why the AnalysisRun said `received non 2xx response code: 400` and nothing else.

| revision | image | `api-test` |
|---|---|---|
| 132 | `0.46.0` | Successful |
| 133 | `0.47.0` | **Error** → `RolloutAborted` |

## Verification

The new body against the live `0.47.0` pod:

```console
$ curl -s -X POST http://bluebird.bluebird-system.svc.cluster.local:8000/api/analyze \
    -H 'content-type: application/json' \
    -d '{"destination_types":["peak"],"forecast_mode":"current","limit":3,"polygon":{...}}' | jq
HTTP 200
{"results": 3, "total_queried": 8,
 "names": ["East Tiger Mountain", "South Tiger Mountain", "West Tiger #1"]}
```

`successCondition: len(result.results) >= 1` → true.

## Not in this PR

zimmertr/bluebird#233 tracks the rest: a contract test in the bluebird repo so a future rename fails the PR instead of the deploy, and the `extra="forbid"` decision that would have made this a named 422 instead of a silent drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)