### PR TITLE
fix(bluebird): stop gating the canary on Open-Meteo's daily quota

### DIFF
--- a/public/bluebird/resources/analysisTemplate-apiTest.yml
+++ b/public/bluebird/resources/analysisTemplate-apiTest.yml
@@ -7,16 +7,31 @@ spec:
     - name: api-test
       count: 1
       failureLimit: 0
-      successCondition: len(result.results) >= 1
+      successCondition: len(result.destinations) >= 1
       provider:
         web:
           method: POST
-          url: http://bluebird-canary.bluebird-system.svc.cluster.local:8000/api/analyze
+          # Discovery, not analysis. This gate proves the new image serves a real
+          # request in this cluster: routing, Istio, the app, request validation,
+          # the Overpass integration and the JSON response path. It deliberately
+          # does NOT reach Open-Meteo.
+          #
+          # It used to POST /api/analyze, which does. Open-Meteo's free tier is
+          # metered per day and a single day of development against it exhausts
+          # it. On 2026-08-05 the endpoint answered `{"error":true,"reason":
+          # "Daily API request limit exceeded. Please try again tomorrow."}`,
+          # /api/analyze returned HTTP 429 with no `results` key, and this gate
+          # could not pass, so nothing could ship. A deploy gate that a donated
+          # third-party quota can jam is a gate that fails hardest at the moment
+          # an operator most needs to ship a fix.
+          #
+          # The forecast path is covered by the suites at PR time (466 pytest,
+          # 1302 Vitest). What only a canary can prove is that THIS image serves
+          # in THIS cluster, and discovery proves that.
+          url: http://bluebird-canary.bluebird-system.svc.cluster.local:8000/api/destinations
           timeoutSeconds: 120
           jsonBody:
             destination_types: [peak]
-            forecast_mode: current
-            limit: 3
             polygon:
               type: Polygon
               coordinates:


### PR DESCRIPTION
Found in the R3 Bluebird launch-readiness review, independently by the k8s/ops auditor and confirmed against production.

## Bluebird cannot deploy today, and the reason is this file

`api-test` POSTs `/api/analyze`, which reaches Open-Meteo **from the pod**. Open-Meteo's free tier is metered per day, and a single day of development against it exhausts it — which is exactly what happened, and is tracked in bluebird#224.

Measured against production at 08:5x UTC on 2026-08-05, using the exact body this template sends:

```
$ curl -s -X POST https://bluebirdforecast.com/api/analyze \
    -H 'Content-Type: application/json' \
    -d '{"destination_types":["peak"],"forecast_mode":"current","limit":3,
         "polygon":{"coordinates":[[[-122.03,47.44],[-121.91,47.44],[-121.91,47.53],
                                    [-122.03,47.53],[-122.03,47.44]]],"type":"Polygon"}}'
{"detail":"Open-Meteo quota reached. Try again later."}
HTTP 429
```

No `results` key, so `len(result.results) >= 1` cannot evaluate true. With `failureLimit: 0` a single failure aborts the analysis and blocks the rollout.

Upstream state, measured independently the same morning:

```
{"error":true,"reason":"Daily API request limit exceeded. Please try again tomorrow."}
HTTP 429
```

## Why this matters more than it looks

1. **It blocks the 1.0.0 cut.** The release is a squash-merge that mints a version and rolls out through this gate. Today that gate cannot pass.
2. **It couples deployability to a third party's free tier.** No amount of care in the app repo makes a release possible on a day Open-Meteo says no.
3. **It jams exactly when you most need to ship.** Quota exhaustion caused by a traffic spike is precisely the moment an operator wants to deploy a fix.
4. **Every deploy spent the pod's forecast quota**, because the probe forced the server-side path that the browser path exists to avoid.

## The change

Repoint the gate at `POST /api/destinations`. A canary's job is to prove **the new code serves correctly**, not that a donated third-party API is up. Those are different questions and only the first should gate a rollout.

Verified against the running app, same Tiger Mountain polygon, unchanged:

```
top-level keys: ['destinations', 'total', 'total_found', 'truncated']
len(result.destinations) = 8   -> successCondition PASSES
```

## What this gives up, stated plainly

The canary no longer exercises the forecast path. That is a real reduction in coverage and it is the deliberate trade: that path is covered by the suites at PR time (466 pytest, 1302 Vitest, both green at bluebird@aeb7af4), whereas what only a canary can prove is that *this image* serves in *this cluster*. Overpass is now the single upstream a deploy depends on, which is a real reduction but not zero.

If forecast coverage in the canary is considered non-negotiable, the alternative is to keep `/api/analyze` and widen the condition to tolerate an honest upstream refusal:

```yaml
successCondition: "len(result.results) >= 1 || result.detail == 'Open-Meteo quota reached. Try again later.'"
```

That is worse, and I did not do it: it hard-codes a user-facing string into a deployment gate, and that string is one Bluebird's own copy rules could change at any time.

## Paired change

`docs/CICD.md:286` in the app repo describes this gate as "a real `/api/analyze` through Overpass and Open-Meteo" and must land with this. Companion PR on zimmertr/bluebird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)