### PR TITLE
feat: preview full-API publish and canary weighting for the public-API route

### DIFF
--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -41,9 +41,10 @@ spec:
               hosts:
                 - "pr-{{ .number }}.ganymede.sol.milkyway"
               # Preview hosts resolve only on the LAN, and the PR containers
-              # are where the analyze API is exercised, so the gateway block
-              # the chart ships by default (bluebird#240) stays off here.
-              exposeAnalyzeApi: true
+              # are where the analyze API is exercised, so the public-API
+              # allowlist the chart ships by default (bluebird#240) is off
+              # here and the whole surface is published.
+              publishFullApi: true
             extraEnv:
               - name: PREVIEW_BANNER
                 value: "true"

--- a/public/bluebird-pr/applicationset.yml
+++ b/public/bluebird-pr/applicationset.yml
@@ -40,6 +40,10 @@ spec:
               enabled: true
               hosts:
                 - "pr-{{ .number }}.ganymede.sol.milkyway"
+              # Preview hosts resolve only on the LAN, and the PR containers
+              # are where the analyze API is exercised, so the gateway block
+              # the chart ships by default (bluebird#240) stays off here.
+              exposeAnalyzeApi: true
             extraEnv:
               - name: PREVIEW_BANNER
                 value: "true"

--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -63,6 +63,11 @@ canary:
         name: bluebird
         routes:
           - bluebird-stable
+          # The public-API allowlist route (bluebird#240). Named here so a
+          # canary weights API traffic too, not only the SPA. Requires the
+          # chart version that renders it: merge AFTER that chart release,
+          # or the next rollout fails to find the route.
+          - bluebird-api-public
 
 ingress:
   enabled: true


### PR DESCRIPTION
Preview and prod halves of zimmertr/bluebird#240, reworked with the chart's allowlist.

- The preview ApplicationSet sets `ingress.publishFullApi: true`: preview hosts resolve only on the LAN, and the PR containers are where the analyze API is exercised.
- Prod's canary `trafficRouting.routes` gains `bluebird-api-public`, the allowlist route the chart now renders, so a canary weights API traffic and not only the SPA.

**Merge order: after the bluebird-helm release that renders the `bluebird-api-public` route.** Argo Rollouts fails a rollout whose `trafficRouting` names a route the VirtualService does not have. The preview half alone would be safe in any order; the prod half is why this waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)