### PR TITLE
chore: bump bluebird image to 0.54.15

### DIFF
--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -16,6 +16,6 @@ resources:
 images:
 - name: zimmertr/bluebird
   newName: zimmertr/bluebird
-  newTag: 0.54.14
+  newTag: 0.54.15
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Automated by the bluebird 0.54.15 release. Rolls the stable app onto the freshly published `zimmertr/bluebird:0.54.15` (triggers the canary rollout).

- Release: https://github.com/zimmertr/bluebird/releases/tag/v0.54.15