### PR TITLE
feat: scrape bluebird and gate the canary on its error rate

### DIFF
--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -11,6 +11,7 @@ helmCharts:
 resources:
 - resources/namespace.yml
 - resources/analysisTemplate-apiTest.yml
+- resources/analysisTemplate-errorRate.yml
 - resources/analysisTemplate-versionCheck.yml
 
 images:

--- a/public/bluebird/resources/analysisTemplate-errorRate.yml
+++ b/public/bluebird/resources/analysisTemplate-errorRate.yml
@@ -1,0 +1,35 @@
+# The metric gate on a canary (bluebird#77, step 8; bluebird#236). The canary
+# serves no user traffic while the steps run — weight stays 0 by choice (TJ,
+# 2026-08-21) — so the 5xx ratio judged here is the canary's synthetic diet:
+# its kubelet probes, the version check, and api-test's full analyze. That is
+# enough to catch a build that crashes, 500s its probes, or fails a real
+# analysis end to end; it cannot see a regression only real traffic finds.
+#
+# Both sides of the ratio guard against empty vectors: `sum()` over no series
+# returns nothing, not zero, and an empty result errors the measurement where
+# a zero passes it. No canary series at all (PodMonitor missing) therefore
+# reads 0/1e-9 = 0 and passes; an UNREACHABLE Prometheus errors the analysis
+# and aborts the rollout — this template must not land before the monitoring
+# stack runs.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: error-rate
+spec:
+  metrics:
+    - name: error-rate
+      # Three checks a minute apart, one forgiven: a stray 500 does not roll
+      # back a release, a repeating one does.
+      interval: 60s
+      count: 3
+      failureLimit: 1
+      successCondition: result[0] < 0.05
+      provider:
+        prometheus:
+          # The operator's own headless service — stable regardless of how
+          # the kube-prometheus-stack release is named.
+          address: http://prometheus-operated.prometheus-system.svc.cluster.local:9090
+          query: |
+            (sum(rate(bluebird_http_requests_total{namespace="bluebird-system",role="canary",status=~"5.."}[2m])) or vector(0))
+            /
+            clamp_min(sum(rate(bluebird_http_requests_total{namespace="bluebird-system",role="canary"}[2m])) or vector(0), 1e-9)

--- a/public/bluebird/values.yml
+++ b/public/bluebird/values.yml
@@ -37,6 +37,14 @@ extraEnv:
   - name: LOG_LEVEL
     value: INFO
 
+# Scrape the pods' Prometheus surface (bluebird#77). Requires the chart
+# version that renders the PodMonitor: merge AFTER that chart release, the
+# same rule as the route note below. On an older chart the value is inert
+# and Prometheus simply has no bluebird targets.
+metrics:
+  podMonitor:
+    enabled: true
+
 useRollout: true
 strategy: Canary
 
@@ -57,6 +65,16 @@ canary:
     - analysis:
         templates:
           - templateName: api-test
+    # Watch the canary's own 5xx ratio in Prometheus before promoting. The
+    # canary takes no user traffic during these steps (weight stays 0), so
+    # the signal is deliberately synthetic: its probes, the version check,
+    # and api-test's full analyze (TJ, 2026-08-21). Needs the monitoring
+    # stack running and the PodMonitor above: with no role="canary" series
+    # the query reads 0 and passes, but an UNREACHABLE Prometheus errors the
+    # analysis and aborts the rollout, so this merges last.
+    - analysis:
+        templates:
+          - templateName: error-rate
   trafficRouting:
     istio:
       virtualService:


### PR DESCRIPTION
The last step of the zimmertr/bluebird#77 series (stack: #658; app: zimmertr/bluebird#289; chart: zimmertr/bluebird-helm#103).

## Changes

- **`metrics.podMonitor.enabled: true`** in the prod values. The chart renders a PodMonitor that scrapes the pods' metrics port directly and copies the `role` label (`stable`/`canary`) onto every series. Against the currently pinned chart (0.11.2) the value is inert; it takes effect with the chart release from bluebird-helm#103.
- **A third canary analysis step, `error-rate`.** After `version-check` and `api-test` pass, a Prometheus analysis watches the canary's 5xx ratio for three checks a minute apart (one failure forgiven, abort at 5%). The canary still takes **no user traffic** during the steps — weight stays 0 by decision (2026-08-21). The judged signal is synthetic on purpose: the canary's probes, the version check, and `api-test`'s full analyze. It catches a build that crashes, 500s its probes, or fails a real analysis; it cannot see what only real traffic finds.
- The template guards both sides of the ratio against empty vectors, so "no canary series" reads 0 and passes rather than erroring the measurement.

## Merge order — this PR merges LAST

1. #658 (the monitoring stack) must be merged and synced first: an **unreachable** Prometheus errors the analysis and aborts every rollout.
2. The bluebird-helm release from bluebird-helm#103 must have landed (its auto-bump PR moves the chart pin here), or the PodMonitor value stays inert and the gate only ever reads zero.

## Verification

- `kustomize build --enable-helm public/bluebird` renders clean; the Rollout carries the three analysis steps in order and the `error-rate` AnalysisTemplate is present.
- The gate adds ~3 minutes to each release. `api-test` still runs exactly one real analyze per rollout against Open-Meteo, unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)