### PR TITLE
fix: name the etcd endpoints so its scrape target exists

### DIFF
--- a/observability/kube-prometheus-stack/values.yml
+++ b/observability/kube-prometheus-stack/values.yml
@@ -65,12 +65,18 @@ grafana:
 # TJs-Kubernetes-Service#58 sets the bind addresses. Until that is applied
 # to the nodes, these targets show down and their *Down alerts fire.
 
-# etcd alone also needs its endpoints NAMED. Talos runs etcd as a host
+# etcd alone also needs its endpoints listed. Talos runs etcd as a host
 # service rather than a kube-system pod, so the chart's selector-based
 # Service matches nothing and the etcd target silently does not exist —
-# absent, not red, which is worse. Naming the control-plane addresses makes
+# absent, not red, which is worse. Listing the control-plane addresses makes
 # the chart build a manual Endpoints object instead; 2381 is the chart's
 # default port and the listener TJs-Kubernetes-Service#58 exposes.
+#
+# Addresses, not the k8s-cp-N hostnames, for two reasons: the Endpoints API
+# only accepts IPs, and a name here would put Unbound inside the etcd
+# monitoring path. These are the DHCP-reserved control-plane addresses that
+# TJs-Kubernetes-Service pins as controlplane_ip_prefix in stable.tfvars —
+# change them there and this list follows.
 kubeEtcd:
   endpoints:
     - 192.168.40.11

--- a/observability/kube-prometheus-stack/values.yml
+++ b/observability/kube-prometheus-stack/values.yml
@@ -65,6 +65,18 @@ grafana:
 # TJs-Kubernetes-Service#58 sets the bind addresses. Until that is applied
 # to the nodes, these targets show down and their *Down alerts fire.
 
+# etcd alone also needs its endpoints NAMED. Talos runs etcd as a host
+# service rather than a kube-system pod, so the chart's selector-based
+# Service matches nothing and the etcd target silently does not exist —
+# absent, not red, which is worse. Naming the control-plane addresses makes
+# the chart build a manual Endpoints object instead; 2381 is the chart's
+# default port and the listener TJs-Kubernetes-Service#58 exposes.
+kubeEtcd:
+  endpoints:
+    - 192.168.40.11
+    - 192.168.40.12
+    - 192.168.40.13
+
 prometheusOperator:
   admissionWebhooks:
     # cert-manager issues the webhook certs. The default is a pair of helm


### PR DESCRIPTION
Found verifying the freshly deployed stack (#658): every target is up **except etcd, which is absent rather than red**. Talos runs etcd as a host service, not a kube-system pod, so the chart's selector-based Service matches no pods and Prometheus never learns the target exists.

The chart's escape hatch is `kubeEtcd.endpoints`: naming the three control-plane addresses makes it render a manual `Endpoints` object (verified in the render: `.11/.12/.13` on port 2381, `http-metrics`, kube-system). The listener itself is already open on all three nodes from zimmertr/TJs-Kubernetes-Service#58 — I verified 2381 answers real etcd metrics.

Safe to merge immediately and independently of #662. After sync, the `kube-etcd` job appears with three up targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why addresses and not the k8s-cp-N hostnames

Reviewed on request. Two reasons, now also in the values comment:

1. The `kubeEtcd.endpoints` mechanism renders a Kubernetes `Endpoints` object, and that API validates `addresses[].ip` as an IP. There is no hostname form of this mechanism.
2. The hostname-capable alternative is a hand-written `additionalScrapeConfigs` static job, which would put Unbound inside the etcd monitoring path (a resolver problem becomes an etcd-visibility gap), bypass the chart's ServiceMonitor and alert wiring, and reintroduce the kind of static scrape job #658 just removed.

These are not free-floating numbers: they are the DHCP-reserved control-plane addresses TJs-Kubernetes-Service pins as `controlplane_ip_prefix` in `stable.tfvars`. Change them there and this list follows.
