### PR TITLE
fix: scrape etcd with a ScrapeConfig; Argo never applies Endpoints

### DIFF
--- a/observability/kube-prometheus-stack/kustomization.yml
+++ b/observability/kube-prometheus-stack/kustomization.yml
@@ -2,6 +2,7 @@ resources:
   - resources/namespace.yml
   - resources/persistentVolume.yml
   - resources/persistentVolumeClaim.yml
+  - resources/scrapeConfig-etcd.yml
 
 namespace: prometheus-system
 

--- a/observability/kube-prometheus-stack/resources/scrapeConfig-etcd.yml
+++ b/observability/kube-prometheus-stack/resources/scrapeConfig-etcd.yml
@@ -1,0 +1,29 @@
+# The etcd scrape, as an operator ScrapeConfig rather than the chart's
+# kubeEtcd.endpoints mechanism. Talos runs etcd as a host service, so there
+# are no pods for the chart's Service selector to find — and the chart's
+# manual-Endpoints fallback cannot be used here because Argo CD's default
+# resource.exclusions drop v1 Endpoints from management, so the rendered
+# object silently never reaches the cluster.
+#
+# Addresses, not the k8s-cp-N hostnames: a name here would put Unbound
+# inside the etcd monitoring path. These are the DHCP-reserved control-plane
+# addresses TJs-Kubernetes-Service pins as controlplane_ip_prefix in
+# stable.tfvars, and 2381 is the metrics listener TJs-Kubernetes-Service#58
+# exposes.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: kube-etcd
+spec:
+  metricsPath: /metrics
+  staticConfigs:
+    - targets:
+        - 192.168.40.11:2381
+        - 192.168.40.12:2381
+        - 192.168.40.13:2381
+  # The generated job label would be "scrapeConfig/prometheus-system/kube-etcd".
+  # Rewritten to the name the chart's own wiring uses, so the shipped etcd
+  # alert rules and Grafana dashboard read these series as chart-native.
+  relabelings:
+    - targetLabel: job
+      replacement: kube-etcd

--- a/observability/kube-prometheus-stack/values.yml
+++ b/observability/kube-prometheus-stack/values.yml
@@ -65,23 +65,14 @@ grafana:
 # TJs-Kubernetes-Service#58 sets the bind addresses. Until that is applied
 # to the nodes, these targets show down and their *Down alerts fire.
 
-# etcd alone also needs its endpoints listed. Talos runs etcd as a host
-# service rather than a kube-system pod, so the chart's selector-based
-# Service matches nothing and the etcd target silently does not exist —
-# absent, not red, which is worse. Listing the control-plane addresses makes
-# the chart build a manual Endpoints object instead; 2381 is the chart's
-# default port and the listener TJs-Kubernetes-Service#58 exposes.
-#
-# Addresses, not the k8s-cp-N hostnames, for two reasons: the Endpoints API
-# only accepts IPs, and a name here would put Unbound inside the etcd
-# monitoring path. These are the DHCP-reserved control-plane addresses that
-# TJs-Kubernetes-Service pins as controlplane_ip_prefix in stable.tfvars —
-# change them there and this list follows.
-kubeEtcd:
-  endpoints:
-    - 192.168.40.11
-    - 192.168.40.12
-    - 192.168.40.13
+# etcd is scraped by resources/scrapeConfig-etcd.yml, NOT by the chart's
+# kubeEtcd.endpoints mechanism. That mechanism renders a v1 Endpoints
+# object, and Argo CD's default resource.exclusions drop Endpoints and
+# EndpointSlice from management entirely — the rendered object is silently
+# never applied, which is how the first attempt shipped Synced-and-Healthy
+# while the etcd target did not exist. kubeEtcd itself stays enabled (the
+# default): the etcd alert rules are gated on it, and the price is a
+# dangling selector-less Service in kube-system that matches nothing.
 
 prometheusOperator:
   admissionWebhooks:
@@ -114,8 +105,12 @@ prometheus:
             regex: '.*-envoy-prom'
     # The default (true) only selects monitors carrying this release's label,
     # which silently ignores monitors shipped by app charts — the bluebird
-    # PodMonitor arrives with the bluebird chart, not with this one.
+    # PodMonitor arrives with the bluebird chart, not with this one. The
+    # scrapeConfig selector gets the same treatment for the etcd
+    # ScrapeConfig, which is a plain resource in this kustomization rather
+    # than a chart-rendered one.
     podMonitorSelectorNilUsesHelmValues: false
+    scrapeConfigSelectorNilUsesHelmValues: false
     serviceMonitorSelectorNilUsesHelmValues: false
     # Size is the only retention bound: history grows until 90GB, then the
     # oldest blocks go — months of data at this cluster's cardinality. The


### PR DESCRIPTION
Supersedes the mechanism from #666, which shipped green but did nothing.

## What happened

#666 used the chart's `kubeEtcd.endpoints`, which renders a `v1 Endpoints` object. Verified against the live cluster: Argo CD's default `resource.exclusions` (in `argocd-cm`) drop `Endpoints` and `EndpointSlice` from management entirely, so the rendered object is never applied — the app reports Synced and Healthy while the etcd target still does not exist. The live Endpoints object's only field manager is `kube-controller-manager`, which created an empty one at 06:47 against the pre-#666 selector Service.

## The fix

- An operator `ScrapeConfig` (`monitoring.coreos.com/v1alpha1`) in `resources/`, static targets on the same three control-plane addresses at 2381, with the `job` label relabeled to `kube-etcd` so the chart's shipped etcd alert rules and Grafana dashboard read the series as chart-native.
- `scrapeConfigSelectorNilUsesHelmValues: false`, the same treatment the ServiceMonitor and PodMonitor selectors already have, since this ScrapeConfig carries no release label.
- The dead `kubeEtcd.endpoints` block is removed. `kubeEtcd` itself stays enabled: the etcd alert rules are gated on it, at the cost of a dangling selector-less Service in kube-system.

Considered and rejected: overriding `resource.exclusions` in the Argo config would mean maintaining a fork of the upstream default exclusion list that silently drifts on every argo-cd chart upgrade, to un-exclude one kind for one object.

## Verification

- Render: exactly one ScrapeConfig, correct namespace and targets, zero Endpoints objects, `scrapeConfigSelector: {}` on the Prometheus CR.
- The listeners themselves already answer on all three nodes (TJs-Kubernetes-Service#58, applied and verified).
- After merge and sync, the `kube-etcd` job appears with three up targets; I will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)