### PR TITLE
chore: bump bluebird image to 0.60.8

### DIFF
--- a/public/bluebird/kustomization.yml
+++ b/public/bluebird/kustomization.yml
@@ -17,6 +17,6 @@ resources:
 images:
 - name: zimmertr/bluebird
   newName: zimmertr/bluebird
-  newTag: 0.60.7
+  newTag: 0.60.8
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Automated by the bluebird 0.60.8 release. Rolls the stable app onto the freshly published `zimmertr/bluebird:0.60.8` (triggers the canary rollout).

- Release: https://github.com/zimmertr/bluebird/releases/tag/v0.60.8