### PR TITLE
chore: point the Bluebird dashboard at the bluebird_forecast_ metric names

### DIFF
--- a/observability/kube-prometheus-stack/files/bluebird-dashboard.json
+++ b/observability/kube-prometheus-stack/files/bluebird-dashboard.json
@@ -74,7 +74,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (route) (rate(bluebird_http_requests_total{route=~\"/api/.*\"}[$__rate_interval]))",
+          "expr": "sum by (route) (rate(bluebird_forecast_http_requests_total{route=~\"/api/.*\"}[$__rate_interval]))",
           "legendFormat": "{{route}}",
           "refId": "A"
         }
@@ -128,7 +128,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (route) (rate(bluebird_http_requests_total{route!~\"/api/.*\"}[$__rate_interval]))",
+          "expr": "sum by (route) (rate(bluebird_forecast_http_requests_total{route!~\"/api/.*\"}[$__rate_interval]))",
           "legendFormat": "{{route}}",
           "refId": "A"
         }
@@ -181,7 +181,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (status) (rate(bluebird_http_requests_total{status=~\"[45]..\"}[$__rate_interval]))",
+          "expr": "sum by (status) (rate(bluebird_forecast_http_requests_total{status=~\"[45]..\"}[$__rate_interval]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -235,7 +235,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.5, sum by (le) (rate(bluebird_http_request_duration_seconds_bucket{route=~\"/api/.*\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(bluebird_forecast_http_request_duration_seconds_bucket{route=~\"/api/.*\"}[$__rate_interval])))",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -244,7 +244,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(bluebird_http_request_duration_seconds_bucket{route=~\"/api/.*\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(bluebird_forecast_http_request_duration_seconds_bucket{route=~\"/api/.*\"}[$__rate_interval])))",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -253,7 +253,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(bluebird_http_request_duration_seconds_bucket{route=~\"/api/.*\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(bluebird_forecast_http_request_duration_seconds_bucket{route=~\"/api/.*\"}[$__rate_interval])))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -319,7 +319,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(bluebird_analyze_destinations_count[1h]))",
+          "expr": "sum(increase(bluebird_forecast_analyze_destinations_count[1h]))",
           "legendFormat": "analyses (server path)",
           "refId": "A"
         },
@@ -328,7 +328,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(bluebird_destinations_returned_count[1h]))",
+          "expr": "sum(increase(bluebird_forecast_destinations_returned_count[1h]))",
           "legendFormat": "discoveries (browser path)",
           "refId": "B"
         }
@@ -382,7 +382,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.5, sum by (le) (rate(bluebird_analyze_destinations_bucket[1h])))",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(bluebird_forecast_analyze_destinations_bucket[1h])))",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -391,7 +391,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(bluebird_analyze_destinations_bucket[1h])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(bluebird_forecast_analyze_destinations_bucket[1h])))",
           "legendFormat": "p95",
           "refId": "B"
         }
@@ -444,7 +444,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (reason) (increase(bluebird_aqi_degraded_total[1h]))",
+          "expr": "sum by (reason) (increase(bluebird_forecast_aqi_degraded_total[1h]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -511,7 +511,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (mirror, outcome) (rate(bluebird_overpass_requests_total[$__rate_interval]))",
+          "expr": "sum by (mirror, outcome) (rate(bluebird_forecast_overpass_requests_total[$__rate_interval]))",
           "legendFormat": "{{mirror}} \u00b7 {{outcome}}",
           "refId": "A"
         }
@@ -564,7 +564,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum by (mirror, le) (rate(bluebird_overpass_request_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (mirror, le) (rate(bluebird_forecast_overpass_request_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "{{mirror}}",
           "refId": "A"
         }
@@ -618,7 +618,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (mirror) (increase(bluebird_overpass_fallback_total[1h]))",
+          "expr": "sum by (mirror) (increase(bluebird_forecast_overpass_fallback_total[1h]))",
           "legendFormat": "left {{mirror}}",
           "refId": "A"
         }
@@ -672,7 +672,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum by (service, le) (rate(bluebird_openmeteo_request_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (service, le) (rate(bluebird_forecast_openmeteo_request_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "{{service}}",
           "refId": "A"
         }
@@ -725,7 +725,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (service, outcome) (rate(bluebird_openmeteo_requests_total[$__rate_interval]))",
+          "expr": "sum by (service, outcome) (rate(bluebird_forecast_openmeteo_requests_total[$__rate_interval]))",
           "legendFormat": "{{service}} \u00b7 {{outcome}}",
           "refId": "A"
         }
@@ -778,7 +778,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (service, scope) (increase(bluebird_openmeteo_rate_limited_total[1h]))",
+          "expr": "sum by (service, scope) (increase(bluebird_forecast_openmeteo_rate_limited_total[1h]))",
           "legendFormat": "{{service}} \u00b7 {{scope}}",
           "refId": "A"
         }
@@ -848,7 +848,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (provider) (rate(bluebird_openmeteo_weight_spent_total[5m])) * 60",
+          "expr": "sum by (provider) (rate(bluebird_forecast_openmeteo_weight_spent_total[5m])) * 60",
           "legendFormat": "{{provider}}",
           "refId": "A"
         }
@@ -902,7 +902,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (provider) (rate(bluebird_upstream_pace_seconds_total[5m]))",
+          "expr": "sum by (provider) (rate(bluebird_forecast_upstream_pace_seconds_total[5m]))",
           "legendFormat": "pace \u00b7 {{provider}}",
           "refId": "A"
         },
@@ -911,7 +911,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum by (provider, le) (rate(bluebird_upstream_queue_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (provider, le) (rate(bluebird_forecast_upstream_queue_seconds_bucket[$__rate_interval])))",
           "legendFormat": "queue p95 \u00b7 {{provider}}",
           "refId": "B"
         }
@@ -978,7 +978,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (cache) (rate(bluebird_cache_hits_total[10m])) / (sum by (cache) (rate(bluebird_cache_hits_total[10m])) + sum by (cache) (rate(bluebird_cache_misses_total[10m])))",
+          "expr": "sum by (cache) (rate(bluebird_forecast_cache_hits_total[10m])) / (sum by (cache) (rate(bluebird_forecast_cache_hits_total[10m])) + sum by (cache) (rate(bluebird_forecast_cache_misses_total[10m])))",
           "legendFormat": "{{cache}}",
           "refId": "A"
         }
@@ -1032,7 +1032,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (cache) (rate(bluebird_cache_hits_total[10m]))",
+          "expr": "sum by (cache) (rate(bluebird_forecast_cache_hits_total[10m]))",
           "legendFormat": "hit \u00b7 {{cache}}",
           "refId": "A"
         },
@@ -1041,7 +1041,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (cache) (rate(bluebird_cache_misses_total[10m]))",
+          "expr": "sum by (cache) (rate(bluebird_forecast_cache_misses_total[10m]))",
           "legendFormat": "miss \u00b7 {{cache}}",
           "refId": "B"
         }
@@ -1107,7 +1107,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (bucket) (increase(bluebird_ratelimit_throttled_total[1h]))",
+          "expr": "sum by (bucket) (increase(bluebird_forecast_ratelimit_throttled_total[1h]))",
           "legendFormat": "{{bucket}}",
           "refId": "A"
         }
@@ -1161,7 +1161,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (provider, mechanism) (increase(bluebird_upstream_shed_total[1h]))",
+          "expr": "sum by (provider, mechanism) (increase(bluebird_forecast_upstream_shed_total[1h]))",
           "legendFormat": "{{provider}} \u00b7 {{mechanism}}",
           "refId": "A"
         }
@@ -1356,7 +1356,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "count by (version) (bluebird_build_info)",
+          "expr": "count by (version) (bluebird_forecast_build_info)",
           "legendFormat": "{{version}}",
           "refId": "A"
         }

--- a/public/bluebird/resources/analysisTemplate-errorRate.yml
+++ b/public/bluebird/resources/analysisTemplate-errorRate.yml
@@ -30,6 +30,6 @@ spec:
           # the kube-prometheus-stack release is named.
           address: http://prometheus-operated.prometheus-system.svc.cluster.local:9090
           query: |
-            (sum(rate(bluebird_http_requests_total{namespace="bluebird-system",role="canary",status=~"5.."}[2m])) or vector(0))
+            (sum(rate(bluebird_forecast_http_requests_total{namespace="bluebird-system",role="canary",status=~"5.."}[2m])) or vector(0))
             /
-            clamp_min(sum(rate(bluebird_http_requests_total{namespace="bluebird-system",role="canary"}[2m])) or vector(0), 1e-9)
+            clamp_min(sum(rate(bluebird_forecast_http_requests_total{namespace="bluebird-system",role="canary"}[2m])) or vector(0), 1e-9)


### PR DESCRIPTION
Do not merge before bluebird release v0.61.0 is live in production. Until then every panel goes blank.

The version number is the next minor release, because zimmertr/bluebird#318 has a `feat:` title. If another `feat:` merges first, the number moves. Check which release contains zimmertr/bluebird#318.

## What changed

`observability/kube-prometheus-stack/files/bluebird-dashboard.json`: every `expr` now queries the `bluebird_forecast_` prefix. 26 of the 29 `expr` values changed, and they hold 28 metric names.

`public/bluebird/resources/analysisTemplate-errorRate.yml`: the canary error-rate gate queries the same counter, so it changes too. This file was not in the issue's scope list. See the note below.

## What was left alone

- `namespace="bluebird-system"` and `container="bluebird"` in the three Kubernetes panels. Issue zimmertr/bluebird#315 renames those.
- The dashboard `uid`, `title`, `tags`, and the `bluebird on GitHub` link. Issues zimmertr/bluebird#311 and zimmertr/bluebird#315 own those.

## The canary gate

The AnalysisTemplate is a second consumer of the metric names. The issue says the dashboard is the only one. A Prometheus query that matches no series reads `0/1e-9 = 0` and passes, as the comment in that file states, so a stale name does not fail the rollout. It makes the gate pass always. That is a silent failure, which is why it is fixed here.

It carries the same merge order as the dashboard, and one cost: the canary of the release that renames the metrics runs against whichever name the gate holds at that moment. One rollout has a gate that passes without measuring. Later rollouts are correct.

The fix is the second commit, so it can be dropped on its own if you want it in a separate pull request.

## What was verified

```
$ jq empty observability/kube-prometheus-stack/files/bluebird-dashboard.json
$ grep -o 'bluebird_forecast_' observability/kube-prometheus-stack/files/bluebird-dashboard.json | wc -l
28
$ grep -rn 'bluebird_' --exclude-dir=.git . | grep -v 'bluebird_forecast_'
(no output)
```

The three `namespace="bluebird-system"` panels, the `uid`, the `tags`, and the link still read `bluebird`, with no underscore, so the grep above does not cover them. They were read by hand.

## Related

- App change: zimmertr/bluebird#318
- Issue: zimmertr/bluebird#313

🤖 Generated with [Claude Code](https://claude.com/claude-code)