### PR TITLE
fix: patched strava-heatmap-proxy image for the personal heatmap

### DIFF
--- a/public/strava-heatmap-proxy/kustomization.yml
+++ b/public/strava-heatmap-proxy/kustomization.yml
@@ -21,7 +21,10 @@ generatorOptions:
 
 images:
   - name: patrickziegler/strava-heatmap-proxy
-    # Upstream publishes :latest plus one tag per commit on main. Pin the commit
-    # tag: Renovate cannot bump it, so bumps are a deliberate edit here.
-    # https://github.com/patrickziegler/strava-heatmap-proxy/commits/main
-    newTag: 3a716f4fa29015452859918df452862f81c50719
+    # Temporarily built from my fork: upstream drops the _strava4_session cookie
+    # after its first refresh, which breaks the personal heatmap (401). The tag
+    # is the fork commit. Switch back to the upstream image and commit tag once
+    # https://github.com/zimmertr/strava-heatmap-proxy-2/pull/1 lands upstream.
+    # Renovate cannot bump commit tags, so bumps are a deliberate edit here.
+    newName: zimmertr/strava-heatmap-proxy
+    newTag: 14dd67e7f0a7a2f8e5fd25bc66fe995b6c0db0c2


### PR DESCRIPTION
## Summary

The personal heatmap route returns 401. Upstream forwards only the cookies Strava returns on its refresh call, and that response never includes `_strava4_session`, which the personal heatmap host requires. Verified by replaying the refresh and the tile request by hand: 401 without the session cookie, 200 with it.

This pins an image built from [zimmertr/strava-heatmap-proxy-2#1](https://github.com/zimmertr/strava-heatmap-proxy-2/pull/1), which always forwards the held session cookie. The image is `zimmertr/strava-heatmap-proxy` tagged with the fork commit, linux/amd64. Swap back to the upstream image once the fix lands upstream.

## Validation

- `kustomize build` renders with the new image.
- After sync: fetch `/personal/grayscale/{z}/{x}/{y}@2x.png?...` through the public hostname and expect 200 image/png.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
